### PR TITLE
Custom Map Targets

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -52,12 +52,13 @@ public sealed partial class MapScreen : BoxContainer
     private TimeSpan _nextMapDequeue;
 
     private float _minMapDequeue = 0.05f;
-    private float _maxMapDequeue = 0.25f;
+    private float _maxMapDequeue = 0.10f; // Frontier: 0.25<0.10
 
     private StyleBoxFlat _ftlStyle;
 
     public event Action<MapCoordinates, Angle>? RequestFTL;
     public event Action<NetEntity, Angle>? RequestBeaconFTL;
+    public event Action<NetEntity?, NetEntity>? RequestTrackEntity; // Frontier
 
     private readonly Dictionary<MapId, BoxContainer> _mapHeadings = new();
     private readonly Dictionary<MapId, List<IMapObject>> _mapObjects = new();
@@ -463,6 +464,16 @@ public sealed partial class MapScreen : BoxContainer
         // If it's our map then scroll, otherwise just set position there.
         MapRadar.SetMap(coordinates.MapId, coordinates.Position, recentering: true);
     }
+	
+    // Frontier: entity tracking
+    private void OnMapObjectTrackPress(IMapObject mapObject)
+    {
+        if (mapObject is not GridMapObject gridObj)
+            return;
+
+        RequestTrackEntity?.Invoke(_shuttleEntity is null ? null : _entManager.GetNetEntity(_shuttleEntity), _entManager.GetNetEntity(gridObj.Entity));
+    }
+    // End Frontier: entity tracking
 
     public void SetMap(MapId mapId, Vector2 position)
     {
@@ -485,6 +496,8 @@ public sealed partial class MapScreen : BoxContainer
             Text = mapObj.Name,
             HorizontalExpand = true,
         };
+		
+        gridButton.Label.ClipText = true; // Frontier
 
         var gridContainer = new BoxContainer()
         {
@@ -492,7 +505,7 @@ public sealed partial class MapScreen : BoxContainer
             {
                 new Control()
                 {
-                    MinWidth = 32f,
+                    MinWidth = 16f, // Frontier: 32<16
                 },
                 gridButton
             }
@@ -505,6 +518,23 @@ public sealed partial class MapScreen : BoxContainer
         {
             OnMapObjectPress(mapObj);
         };
+		
+        // Frontier: tracking button handler
+        if (mapObj is GridMapObject gridObj)
+        {
+            var trackButton = new Button()
+            {
+                Text = Loc.GetString("shuttle-console-map-track"),
+                MinWidth = 32,
+                MaxWidth = 32
+            };
+            trackButton.OnPressed += args =>
+            {
+                OnMapObjectTrackPress(mapObj);
+            };
+            gridContainer.Children.Add(trackButton);
+        }
+        // End Frontier: tracking button handler
 
         if (gridContents.ChildCount > 1)
         {

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -141,6 +141,35 @@
                     </controls:BoxContainer>
                     </controls:PanelContainer>
                     <!-- End Frontier - Inertia dampener controls-->
+					
+                    <!-- Frontier - settable target -->
+                    <controls:BoxContainer Orientation="Vertical" HorizontalExpand="True" Name="TargetCoordsBox">
+                        <controls:Label Text="{controls:Loc 'shuttle-console-target'}"/>
+                        <controls:BoxContainer Orientation="Horizontal"
+                                               HorizontalExpand="True"
+                                               Align="Center"
+                                               Margin="0 0 0 3">
+                            <controls:LineEdit Name="TargetX" Access="Public" HorizontalExpand="True"/>
+                            <controls:LineEdit Name="TargetY" Access="Public" HorizontalExpand="True"/>
+                            <controls:Button Name="TargetSet"
+                                             Text="{controls:Loc 'shuttle-console-set-target'}"
+                                             TextAlign="Center"
+                                             MinWidth="20"
+                                             ToolTip="{controls:Loc 'shuttle-console-set-target-description'}"
+                                             StyleClasses="OpenRight"
+                                             Margin="0"/>
+                            <controls:Button Name="TargetShow"
+                                             Text="{controls:Loc 'shuttle-console-hide-target'}"
+                                             TextAlign="Center"
+                                             ToggleMode="True"
+                                             MinWidth="20"
+                                             ToolTip="{controls:Loc 'shuttle-console-hide-target-description'}"
+                                             StyleClasses="OpenLeft"
+                                             Margin="0"/>
+                        </controls:BoxContainer>
+                    </controls:BoxContainer>
+                    <!-- End Frontier - settable target -->
+
                     <!-- Frontier - IFF search -->
                     <controls:PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="4 4 4 4">
                         <controls:PanelContainer.PanelOverride>

--- a/Content.Client/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml.cs
@@ -118,7 +118,7 @@ public sealed partial class NavScreen : BoxContainer
         // Update port names if custom names are available
         UpdateNetworkPortButtonNames(scc.NetworkPortNames);
 
-        NfUpdateState(); // Frontier Update State
+        NfUpdateState(scc); // Frontier Update State
     }
 
     /// <summary>

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
     public event Action<NetEntity>? UndockRequest;
     public event Action<List<NetEntity>>? UndockAllRequest;
     public event Action<List<NetEntity>, bool>? ToggleFTLLockRequest;
+    public event Action<NetEntity?, NetEntity>? RequestTrackEntity; // Frontier
 
     public ShuttleConsoleWindow()
     {
@@ -54,6 +55,13 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         {
             RequestBeaconFTL?.Invoke(ent, angle);
         };
+		
+        // Frontier: entity tracking
+        MapContainer.RequestTrackEntity += (ent, trackEntity) =>
+        {
+            RequestTrackEntity?.Invoke(ent, trackEntity);
+        };
+        // End Frontie
 
         DockContainer.DockRequest += (entity, netEntity) =>
         {

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -276,12 +276,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
 
         RotateWithEntity = state.RotateWithEntity;
 
-        // Frontier
-        if (state.MaxIffRange != null)
-            MaximumIFFDistance = state.MaxIffRange.Value;
-        HideCoords = state.HideCoords;
-        // End Frontier
-
         _docks = state.Docks;
 
         NfUpdateState(state); // Frontier Update State
@@ -560,9 +554,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                 // End Frontier: IFF drawing functions
             }
 
-            // Frontier Don't skip drawing blips if they're out of range.
-            NfDrawBlips(handle, blipDataList);
-
             // Detailed view
             var gridAABB = curGridToWorld.TransformBox(grid.Comp.LocalAABB);
 
@@ -577,6 +568,96 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                 DrawDocks(handle, gUid, curGridToView);
             }
         }
+		
+        // Frontier: draw target
+        if (!HideTarget && Target is { } target)
+        {
+            var targetEntity = EntManager.GetEntity(TargetEntity);
+
+            string targetName;
+            if (EntManager.TryGetComponent<MetaDataComponent>(targetEntity, out var targetMeta))
+                targetName = targetMeta.EntityName;
+            else
+                targetName = Loc.GetString("shuttle-console-target-name");
+
+            var curGridToView = Matrix3Helpers.CreateTranslation(target) * worldToShuttle * shuttleToView;
+
+            var labelColor = TargetColor;
+            var coordColor = new Color(TargetColor.R * 0.8f, TargetColor.G * 0.8f, TargetColor.B * 0.8f, 0.5f);
+
+            //var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
+            //gridCentre.Y = -gridCentre.Y;
+
+            // Frontier: IFF drawing functions
+            // The actual position in the UI. We offset the matrix position to render it off by half its width
+            // plus by the offset.
+            //var uiPosition = ScalePosition(gridCentre) / UIScale;
+            var uiPosition = Vector2.Transform(Vector2.Zero, curGridToView) / UIScale;
+
+            // Confines the UI position within the viewport.
+            var uiXCentre = (int) Width / 2;
+            var uiYCentre = (int) Height / 2;
+            var uiXOffset = uiPosition.X - uiXCentre;
+            var uiYOffset = uiPosition.Y - uiYCentre;
+            var uiDistance = (int) Math.Sqrt(Math.Pow(uiXOffset, 2) + Math.Pow(uiYOffset, 2));
+            var uiX = uiXCentre * uiXOffset / uiDistance;
+            var uiY = uiYCentre * uiYOffset / uiDistance;
+
+            var isOutsideRadarCircle = uiDistance > Math.Abs(uiX) && uiDistance > Math.Abs(uiY);
+            if (isOutsideRadarCircle)
+            {
+                // 0.95f for offsetting the icons slightly away from edge of radar so it doesnt clip.
+                uiX = uiXCentre * uiXOffset / uiDistance * 0.95f;
+                uiY = uiYCentre * uiYOffset / uiDistance * 0.95f;
+                uiPosition = new Vector2(
+                    x: uiX + uiXCentre,
+                    y: uiY + uiYCentre
+                );
+            }
+
+            var scaledMousePosition = GetMouseCoordinatesFromCenter().Position * UIScale;
+            var isMouseOver = Vector2.Distance(scaledMousePosition, uiPosition * UIScale) < 30f;
+
+            var distance = Vector2.Distance(target, mapPos.Position);
+
+            // Shows decimal when distance is < 50m, otherwise pointless to show it.
+            var displayedDistance = distance < 50f ? $"{distance:0.0}" : distance < 1000 ? $"{distance:0}" : $"{distance / 1000:0.0}k";
+            var labelText = Loc.GetString("shuttle-console-iff-label", ("name", targetName)!, ("distance", displayedDistance));
+
+            var coordsText = $"({target.X:0.0}, {target.Y:0.0})";
+
+            // Calculate unscaled offsets.
+            var labelDimensions = handle.GetDimensions(Font, labelText, 1f);
+            var blipSize = RadarBlipSize * 0.7f;
+            var labelOffset = new Vector2()
+            {
+                X = uiPosition.X > Width / 2f
+                    ? -labelDimensions.X - blipSize // right align the text to left of the blip
+                    : blipSize, // left align the text to the right of the blip
+                Y = -labelDimensions.Y / 2f
+            };
+
+            handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, labelText, UIScale, labelColor);
+            if (isMouseOver && !HideCoords)
+            {
+                var coordDimensions = handle.GetDimensions(Font, coordsText, 0.7f);
+                var coordOffset = new Vector2()
+                {
+                    X = uiPosition.X > Width / 2f
+                        ? -coordDimensions.X - blipSize / 0.7f // right align the text to left of the blip (0.7 needed for scale)
+                        : blipSize, // left align the text to the right of the blip
+                    Y = coordDimensions.Y / 2
+                };
+                handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, coordColor);
+            }
+
+            NfAddBlipToList(blipDataList, isOutsideRadarCircle, uiPosition, uiXCentre, uiYCentre, labelColor); // Frontier code
+            // End Frontier: IFF drawing functions
+        }
+
+        // Draw all blips on the map at this point.
+        NfDrawBlips(handle, blipDataList);
+        // End Frontier: draw target
 
         // If we've set the controlling console, and it's on a different grid
         // to the shuttle itself, then draw an additional marker to help the

--- a/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -1,6 +1,7 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Client.Shuttles.UI;
 using Content.Shared._NF.Shuttles.Events;
 
@@ -14,6 +15,9 @@ namespace Content.Client.Shuttles.BUI
             _window.OnInertiaDampeningModeChanged += OnInertiaDampeningModeChanged;
             _window.OnMaxShuttleSpeedChanged += OnMaxShuttleSpeedChanged;
             _window.OnNetworkPortButtonPressed += OnNetworkPortButtonPressed;
+	    _window.OnSetTargetCoordinates += OnSetTargetCoordinates;
+            _window.OnSetHideTarget += OnSetHideTarget;
+            _window.RequestTrackEntity += OnTrackEntity;
         }
         private void OnInertiaDampeningModeChanged(NetEntity? entityUid, InertiaDampeningMode mode)
         {
@@ -39,6 +43,34 @@ namespace Content.Client.Shuttles.BUI
             {
                 SourcePort = sourcePort,
                 TargetPort = targetPort
+            });
+        }
+		
+        private void OnSetTargetCoordinates(NetEntity? entityUid, Vector2 position)
+        {
+            SendMessage(new SetTargetCoordinatesRequest
+            {
+                ShuttleEntityUid = entityUid,
+                TrackedPosition = position,
+                TrackedEntity = NetEntity.Invalid
+            });
+        }
+
+        private void OnSetHideTarget(NetEntity? entityUid, bool hide)
+        {
+            SendMessage(new SetHideTargetRequest
+            {
+                Hidden = hide
+            });
+        }
+
+        private void OnTrackEntity(NetEntity? entityUid, NetEntity trackEntity)
+        {
+            SendMessage(new SetTargetCoordinatesRequest
+            {
+                ShuttleEntityUid = entityUid,
+                TrackedPosition = Vector2.Zero, // don't care
+                TrackedEntity = trackEntity
             });
         }
     }

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -1,7 +1,9 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.BUIStates;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.Shuttles.UI
@@ -12,6 +14,10 @@ namespace Content.Client.Shuttles.UI
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<NetEntity?, float>? OnMaxShuttleSpeedChanged;
         public event Action<string, string>? OnNetworkPortButtonPressed;
+        public event Action<NetEntity?, Vector2>? OnSetTargetCoordinates;
+        public event Action<NetEntity?, bool>? OnSetHideTarget;
+		
+        private bool _targetCoordsModified = false;
 
         private void NfInitialize()
         {
@@ -47,6 +53,11 @@ namespace Content.Client.Shuttles.UI
             // Send off a request to get the current dampening mode.
             _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
             OnInertiaDampeningModeChanged?.Invoke(shuttle, InertiaDampeningMode.Query);
+			
+            TargetX.OnTextChanged += _ => _targetCoordsModified = true;
+            TargetY.OnTextChanged += _ => _targetCoordsModified = true;
+            TargetSet.OnPressed += _ => SetTargetCoords();
+            TargetShow.OnPressed += _ => SetHideTarget(!TargetShow.Pressed);
         }
 
         private void OnPortButtonPressed(string sourcePort, string targetPort)
@@ -61,7 +72,7 @@ namespace Content.Client.Shuttles.UI
             OnInertiaDampeningModeChanged?.Invoke(shuttle, mode);
         }
 
-        private void NfUpdateState()
+        private void NfUpdateState(NavInterfaceState state)
         {
             if (NavRadar.DampeningMode == InertiaDampeningMode.Station)
             {
@@ -90,12 +101,28 @@ namespace Content.Client.Shuttles.UI
                     AnchorOn.Disabled = false;
                 }
             }
+			
+            TargetShow.Pressed = !state.HideTarget;
+            if (!_targetCoordsModified)
+            {
+                if (state.Target != null)
+                {
+                    var target = state.Target.Value;
+                    TargetX.Text = target.X.ToString("F1");
+                    TargetY.Text = target.Y.ToString("F1");
+                }
+                else
+                {
+                    TargetX.Text = 0.0f.ToString("F1");
+                    TargetY.Text = 0.0f.ToString("F1");
+                }
+			}
         }
 
         // Frontier - Maximum IFF Distance
         private void OnRangeFilterChanged(int value)
         {
-            NavRadar.MaximumIFFDistance = (float) value;
+            NavRadar.MaximumIFFDistance = value;
         }
 
         // Frontier - Maximum Shuttle Speed
@@ -139,6 +166,27 @@ namespace Content.Client.Shuttles.UI
             }
             // End Frontier - PR #1284
         }
+		
+        private void SetTargetCoords()
+        {
+            Vector2 outputVector;
+            if (!float.TryParse(TargetX.Text, out outputVector.X))
+                outputVector.X = 0.0f;
 
+            if (!float.TryParse(TargetY.Text, out outputVector.Y))
+                outputVector.Y = 0.0f;
+
+            NavRadar.Target = outputVector;
+            NavRadar.TargetEntity = NetEntity.Invalid;
+            _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+            OnSetTargetCoordinates?.Invoke(shuttle, outputVector);
+            _targetCoordsModified = false;
+        }
+
+        private void SetHideTarget(bool hide)
+        {
+            _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+            OnSetHideTarget?.Invoke(shuttle, hide);
+        }
     }
 }

--- a/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -1,6 +1,7 @@
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
+using System.Numerics;
 using Content.Shared._NF.Shuttles.Events;
 
 namespace Content.Client.Shuttles.UI
@@ -10,6 +11,8 @@ namespace Content.Client.Shuttles.UI
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<NetEntity?, float>? OnMaxShuttleSpeedChanged;
         public event Action<string, string>? OnNetworkPortButtonPressed;
+        public event Action<NetEntity?, Vector2>? OnSetTargetCoordinates;
+        public event Action<NetEntity?, bool>? OnSetHideTarget;
 
         private void NfInitialize()
         {
@@ -26,6 +29,16 @@ namespace Content.Client.Shuttles.UI
             NavContainer.OnNetworkPortButtonPressed += (sourcePort, targetPort) =>
             {
                 OnNetworkPortButtonPressed?.Invoke(sourcePort, targetPort);
+            };
+			
+            NavContainer.OnSetTargetCoordinates += (entity, position) =>
+            {
+                OnSetTargetCoordinates?.Invoke(entity, position);
+            };
+			
+            NavContainer.OnSetHideTarget += (entity, hide) =>
+            {
+                OnSetHideTarget?.Invoke(entity, hide);
             };
         }
     }

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -15,6 +15,7 @@ namespace Content.Client.Shuttles.UI
 {
     public partial class ShuttleNavControl // Mono
     {
+	private static readonly Color TargetColor = Color.FromHex("#99ff66");
         public InertiaDampeningMode DampeningMode { get; set; }
 
         /// <summary>
@@ -22,13 +23,23 @@ namespace Content.Client.Shuttles.UI
         /// while in FTL to prevent parking while traveling.
         /// </summary>
         public bool InFtl { get; set; }
+		
+		public bool HideTarget { get; set; } = false;
+		public Vector2? Target { get; set; } = null;
+		public NetEntity? TargetEntity { get; set; } = null;
 
         private void NfUpdateState(NavInterfaceState state)
         {
+			if (state.MaxIffRange != null)
+				MaximumIFFDistance = state.MaxIffRange.Value;
+			HideCoords = state.HideCoords;
+			Target = state.Target;
+			TargetEntity = state.TargetEntity;
+			HideTarget = state.HideTarget;
 
             if (!EntManager.GetCoordinates(state.Coordinates).HasValue ||
                 !EntManager.TryGetComponent(EntManager.GetCoordinates(state.Coordinates).GetValueOrDefault().EntityId,out TransformComponent? transform) ||
-                !EntManager.TryGetComponent(transform.GridUid, out PhysicsComponent? physicsComponent))
+                !EntManager.HasComponent<PhysicsComponent>(transform.GridUid))
             {
                 return;
             }

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -43,13 +43,13 @@ namespace Content.Server.Shuttles.Components
         /// <summary>
         ///     While disabled by EMP
         /// </summary>
-        [DataField("timeoutFromEmp", customTypeSerializer: typeof(TimeOffsetSerializer))]
+        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
         public TimeSpan TimeoutFromEmp = TimeSpan.Zero;
 
-        [DataField("disableDuration"), ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float DisableDuration = 60f;
 
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public InertiaDampeningMode DampeningMode = InertiaDampeningMode.Dampen;
         // End Frontier
 

--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -9,13 +9,15 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Content.Shared.PowerCell;
 using Content.Shared.Movement.Components;
+using Content.Server.Shuttles.Components; // Frontier
 
 namespace Content.Server.Shuttles.Systems;
 
-public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
+public sealed partial class RadarConsoleSystem : SharedRadarConsoleSystem
 {
     [Dependency] private readonly ShuttleConsoleSystem _console = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly TransformSystem _transform = default!; // Frontier
 
     public override void Initialize()
     {
@@ -68,9 +70,39 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
             if (component.MaxIffRange != null)
                 state.MaxIffRange = component.MaxIffRange.Value;
             state.HideCoords = component.HideCoords;
+            state.Target = component.Target;
+            state.TargetEntity = GetNetEntity(component.TargetEntity);
+            state.HideTarget = component.HideTarget;
             // End Frontier
 
             _uiSystem.SetUiState(uid, RadarConsoleUiKey.Key, new NavBoundUserInterfaceState(state));
         }
     }
+	
+    // Frontier: settable waypoints
+    public void SetTarget(Entity<RadarConsoleComponent> ent, NetEntity targetEntity, Vector2 target)
+    {
+        // Try to get entity
+        if (EntityManager.TryGetEntity(targetEntity, out var targetUid)
+            && HasComp<ShuttleComponent>(targetUid)
+            && (!TryComp(targetUid, out IFFComponent? iff) || (iff.Flags & (IFFFlags.Hide | IFFFlags.HideLabel)) == 0)
+            && TryComp(targetUid, out TransformComponent? xform))
+        {
+            ent.Comp.TargetEntity = targetUid.Value;
+            ent.Comp.Target = _transform.GetMapCoordinates(xform).Position;
+        }
+        else
+        {
+            ent.Comp.Target = target;
+            ent.Comp.TargetEntity = null;
+        }
+        Dirty(ent);
+    }
+
+    public void SetHideTarget(Entity<RadarConsoleComponent> ent, bool hideTarget)
+    {
+        ent.Comp.HideTarget = hideTarget;
+        Dirty(ent);
+    }
+    // End Frontier
 }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -418,7 +418,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         }
         else
         {
-            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen); // Frontier: inertia dampening);
+            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen, null, true, false, null, NetEntity.Invalid, true); // Frontier: inertia dampening
             mapState = new ShuttleMapInterfaceState(
                 FTLState.Invalid,
                 default,
@@ -533,7 +533,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     public NavInterfaceState GetNavState(Entity<RadarConsoleComponent?, TransformComponent?> entity, Dictionary<NetEntity, List<DockingPortState>> docks)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2, false))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampen); // Frontier: add inertia dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, InertiaDampeningMode.Dampen, null, true, false, null, NetEntity.Invalid, true); // Frontier: add inertia dampening, target
 
         // Get port names from the console component if available
         var portNames = new Dictionary<string, string>();
@@ -558,7 +558,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         Dictionary<string, string>? portNames = null)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2, false))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen); // Frontier: add inertial dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen, null, true, false, null, NetEntity.Invalid, true); // Frontier: add inertial dampening, target
 
         return new NavInterfaceState(
             entity.Comp1.MaxRange,
@@ -568,7 +568,10 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier: inertia dampening
             portNames,
             entity.Comp1.Pannable, // Mono
-            entity.Comp1.RelativePanning); // Mono
+            entity.Comp1.RelativePanning, // Mono
+            entity.Comp1.Target, // Frontier
+            GetNetEntity(entity.Comp1.TargetEntity), // Frontier
+            entity.Comp1.HideTarget); // Frontier
     }
 
     /// <summary>

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -7,12 +7,14 @@ using Content.Shared._NF.Shuttles.Events;
 using Content.Shared._NF.Shipyard.Components;
 using Content.Server._Mono.Shuttles.Components;
 using Robust.Shared.Physics; // Mono
+using Content.Shared.Shuttles.Components;
 using Robust.Shared.Physics.Components;
 
 namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
+    [Dependency] private readonly RadarConsoleSystem _radarConsole = default!;
     private const float SpaceFrictionStrength = 0.0075f;
     private const float DampenDampingStrength = 0.25f;
     private const float AnchorDampingStrength = 2.5f;
@@ -20,6 +22,8 @@ public sealed partial class ShuttleSystem
     {
         SubscribeLocalEvent<ShuttleConsoleComponent, SetInertiaDampeningRequest>(OnSetInertiaDampening);
         SubscribeLocalEvent<ShuttleConsoleComponent, SetMaxShuttleSpeedRequest>(OnSetMaxShuttleSpeed);
+        SubscribeLocalEvent<ShuttleConsoleComponent, SetTargetCoordinatesRequest>(NfSetTargetCoordinates);
+        SubscribeLocalEvent<ShuttleConsoleComponent, SetHideTargetRequest>(NfSetHideTarget);
     }
 
     private bool SetInertiaDampening(EntityUid uid, PhysicsComponent physicsComponent, ShuttleComponent shuttleComponent, TransformComponent transform, InertiaDampeningMode mode)
@@ -142,5 +146,37 @@ public sealed partial class ShuttleSystem
             }
         }
     }
+	
+    public void NfSetTargetCoordinates(EntityUid uid, ShuttleConsoleComponent component, SetTargetCoordinatesRequest args)
+    {
+        if (!TryComp<RadarConsoleComponent>(uid, out var radarConsole))
+            return;
 
+        var transform = Transform(uid);
+        // Get the grid entity from the console transform
+        if (!transform.GridUid.HasValue)
+            return;
+
+        var gridUid = transform.GridUid.Value;
+
+        _radarConsole.SetTarget((uid, radarConsole), args.TrackedEntity, args.TrackedPosition);
+        _radarConsole.SetHideTarget((uid, radarConsole), false); // Force target visibility
+        _console.RefreshShuttleConsoles(gridUid);
+    }
+
+    public void NfSetHideTarget(EntityUid uid, ShuttleConsoleComponent component, SetHideTargetRequest args)
+    {
+        if (!TryComp<RadarConsoleComponent>(uid, out var radarConsole))
+            return;
+
+        var transform = Transform(uid);
+        // Get the grid entity from the console transform
+        if (!transform.GridUid.HasValue)
+            return;
+
+        var gridUid = transform.GridUid.Value;
+
+        _radarConsole.SetHideTarget((uid, radarConsole), args.Hidden);
+        _console.RefreshShuttleConsoles(gridUid);
+    }
 }

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -1,6 +1,8 @@
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
-using Content.Shared._NF.Shuttles.Events; // Frontier - InertiaDampeningMode access
+using Content.Shared._NF.Shuttles.Events; // Frontier
+using Content.Shared.Shuttles.Components; // Frontier
+using System.Numerics; // Frontier - InertiaDampeningMode access
 
 namespace Content.Shared.Shuttles.BUIStates;
 
@@ -29,7 +31,7 @@ public sealed class NavInterfaceState
     /// </summary>
     public Dictionary<string, string> NetworkPortNames = new();
 
-    // Frontier fields
+    /// Frontier fields
     /// <summary>
     /// Frontier - the state of the shuttle's inertial dampeners
     /// </summary>
@@ -44,6 +46,21 @@ public sealed class NavInterfaceState
     /// Frontier: settable coordinate visibility
     /// </summary>
     public bool HideCoords = false;
+	
+    /// <summary>
+    /// A settable target to show on radar
+    /// </summary>
+    public Vector2? Target { get; set; }
+
+    /// <summary>
+    /// A settable target to show on radar
+    /// </summary>
+    public NetEntity? TargetEntity { get; set; }
+
+    /// <summary>
+    /// Frontier: whether or not to show the target coords
+    /// </summary>
+    public bool HideTarget = true;
     // End Frontier fields
 
     public bool Pannable = true; // Mono
@@ -57,7 +74,10 @@ public sealed class NavInterfaceState
         InertiaDampeningMode dampeningMode, // Frontier: add dampeningMode
         Dictionary<string, string>? networkPortNames = null,
         bool pannable = true, // Mono
-        bool relativePan = false) // Mono
+        bool relativePan = false, // Mono
+        Vector2? target = null, // Frontier
+        NetEntity? targetEntity = null, // Frontier
+        bool hideTarget = true) // Frontier
     {
         MaxRange = maxRange;
         Coordinates = coordinates;
@@ -67,6 +87,9 @@ public sealed class NavInterfaceState
         NetworkPortNames = networkPortNames ?? new Dictionary<string, string>();
         Pannable = pannable; // Mono
         RelativePanning = relativePan; // Mono
+        Target = target; // Frontier
+        TargetEntity = targetEntity; // Frontier
+        HideTarget = hideTarget; // Frontier
     }
 }
 

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Shuttles.Systems;
 using Robust.Shared.GameStates;
+using System.Numerics; // Frontier
 
 namespace Content.Shared.Shuttles.Components;
 
@@ -38,6 +39,23 @@ public sealed partial class RadarConsoleComponent : Component
     /// </summary>
     [DataField]
     public bool HideCoords = false;
+    /// <summary>
+    /// A settable target to display on IFF
+    /// </summary>
+    [DataField]
+    public Vector2? Target;
+
+    /// <summary>
+    /// If not null, the target whose information will be displayed on the radar.
+    /// </summary>
+    [DataField]
+    public EntityUid? TargetEntity;
+
+    /// <summary>
+    /// Whether or not to display the target IFF
+    /// </summary>
+    [DataField]
+    public bool HideTarget = false;
     // End Frontier
 
     // <Mono>

--- a/Content.Shared/Shuttles/Events/SetTrackedCoordinatesRequest.cs
+++ b/Content.Shared/Shuttles/Events/SetTrackedCoordinatesRequest.cs
@@ -1,0 +1,32 @@
+// New Frontiers - This file is licensed under AGPLv3
+// Copyright (c) 2024 New Frontiers Contributors
+// See AGPLv3.txt for details.
+
+using System.Numerics;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Shuttles.Events;
+
+/// <summary>
+/// Raised on the client when it wishes to track a particular coordinate.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class SetTargetCoordinatesRequest : BoundUserInterfaceMessage
+{
+    public NetEntity? ShuttleEntityUid { get; set; }
+    public Vector2 TrackedPosition { get; set; }
+    /// <summary>
+    /// The entity that is being tracked.
+    /// Currently only used for ID purposes, does not actually track the entity.
+    /// </summary>
+    public NetEntity TrackedEntity { get; set; }
+}
+
+/// <summary>
+/// Raised on the client when it wishes to hide or show the target.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class SetHideTargetRequest : BoundUserInterfaceMessage
+{
+    public bool Hidden { get; set; }
+}

--- a/Resources/Locale/en-US/_NF/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_NF/shuttles/console.ftl
@@ -25,3 +25,12 @@ shuttle-console-device-button-5 = Port 5
 shuttle-console-device-button-6 = Port 6
 shuttle-console-device-button-7 = Port 7
 shuttle-console-device-button-8 = Port 8
+
+# Radar Target Buttons
+shuttle-console-target = Radar Target
+shuttle-console-set-target = Set
+shuttle-console-set-target-description = Sets a target waypoint coordinate on the radar console.
+shuttle-console-hide-target = Show
+shuttle-console-hide-target-description = Toggles the visibility of the target waypoint on the radar console.
+shuttle-console-target-name = Target
+shuttle-console-map-track = ⌖

--- a/Resources/Locale/ru-RU/_NF/shuttles/console.ftl
+++ b/Resources/Locale/ru-RU/_NF/shuttles/console.ftl
@@ -2,16 +2,20 @@ shuttle-console-designation = Кодовый номер:
 shuttle-console-designation-unknown = ???
 shuttle-console-maximum-iff-distance = Дальность опазнования
 shuttle-console-maximum-speed = Максимум скорости шаттла
+
 shuttle-console-iff-search = Поиск по системе опазнования
 shuttle-console-inertia-dampener-off = Круиз
 shuttle-console-inertia-dampener-dampen = Полёт
 shuttle-console-inertia-dampener-anchor = Парковка
+
 # Mono
 shuttle-console-force-anchored = Вы не можете совершить БСС прыжок на аванпосте.
 shuttle-console-signature-infrared = Термальная сигнатура
 shuttle-console-signature-unknown = Неизвестно
+
 # Network Port Buttons
 shuttle-console-network-ports = Сетевые порты
+
 # Device Link Buttons
 shuttle-console-device-button-1 = Порт 1
 shuttle-console-device-button-2 = Порт 2
@@ -21,3 +25,12 @@ shuttle-console-device-button-5 = Порт 5
 shuttle-console-device-button-6 = Порт 6
 shuttle-console-device-button-7 = Порт 7
 shuttle-console-device-button-8 = Порт 8
+
+# Radar Target Buttons
+shuttle-console-target = Навигационная метка
+shuttle-console-set-target = Установить
+shuttle-console-set-target-description = Устанавливает координаты навигационной метки на радаре.
+shuttle-console-hide-target = Показать
+shuttle-console-hide-target-description = Переключает отображение навигационной метки на радаре.
+shuttle-console-target-name = Цель
+shuttle-console-map-track = ⌖


### PR DESCRIPTION
Порт возможности ставить метки с new frontier ([ссылка на пр](https://github.com/new-frontiers-14/frontier-station-14/pull/3650))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added radar target setting with coordinate input controls on the navigation screen
- Added ability to toggle target visibility on the radar display
- Added entity tracking from map view to set targets directly on the radar
- Improved map refresh responsiveness for faster updates
- Added localized UI labels and descriptions for all new targeting controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->