### PR TITLE
console announsment + character desc improve

### DIFF
--- a/Content.Shared/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.cs
@@ -34,7 +34,7 @@ public sealed partial class CCVars
         CVarDef.Create("chat.max_message_length", 1000, CVar.SERVER | CVar.REPLICATED);
 
     public static readonly CVarDef<int> ChatMaxAnnouncementLength =
-        CVarDef.Create("chat.max_announcement_length", 256, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("chat.max_announcement_length", 1024, CVar.SERVER | CVar.REPLICATED); // Exodus-More-Symbols-In-Announce-Console (256->1024)
 
     public static readonly CVarDef<bool> ChatSanitizerEnabled =
         CVarDef.Create("chat.chat_sanitizer_enabled", true, CVar.SERVERONLY);

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -32,7 +32,7 @@ namespace Content.Shared.Preferences
 
         public const int MaxNameLength = 32;
         public const int MaxLoadoutNameLength = 32;
-        public const int MaxDescLength = 512;
+        public const int MaxDescLength = 2048; // Exodus-More-Symbols-In-Character-Desc (512->2048)
 
         public const int DefaultBalance = 75000;
 


### PR DESCRIPTION
## Описание
Увеличено количество символов в консоли оповещений + в описании персонажа

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Chat announcement messages now support longer content, with character limit increased to 1024 from 256
  * Character descriptions expanded to support up to 2048 characters (from 512), enabling more detailed flavor text customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->