### PR TITLE
poi no ram

### DIFF
--- a/Resources/Maps/_Mono/POI/anomalouslab.yml
+++ b/Resources/Maps/_Mono/POI/anomalouslab.yml
@@ -143,6 +143,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/camelot.yml
+++ b/Resources/Maps/_Mono/POI/camelot.yml
@@ -225,6 +225,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/derelictdrillsite.yml
+++ b/Resources/Maps/_Mono/POI/derelictdrillsite.yml
@@ -205,6 +205,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/pdvhelios.yml
+++ b/Resources/Maps/_Mono/POI/pdvhelios.yml
@@ -226,6 +226,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/sevastopol.yml
+++ b/Resources/Maps/_Mono/POI/sevastopol.yml
@@ -147,6 +147,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/tsfmchalcyon.yml
+++ b/Resources/Maps/_Mono/POI/tsfmchalcyon.yml
@@ -236,6 +236,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_Mono/POI/tsfmcoutpost.yml
+++ b/Resources/Maps/_Mono/POI/tsfmcoutpost.yml
@@ -83,6 +83,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/arena.yml
+++ b/Resources/Maps/_NF/POI/arena.yml
@@ -134,6 +134,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/bahama.yml
+++ b/Resources/Maps/_NF/POI/bahama.yml
@@ -97,6 +97,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/beacon.yml
+++ b/Resources/Maps/_NF/POI/beacon.yml
@@ -80,6 +80,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/cargodepot.yml
+++ b/Resources/Maps/_NF/POI/cargodepot.yml
@@ -55,6 +55,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: BecomesStation
       id: CargoDepot
     - type: DecalGrid

--- a/Resources/Maps/_NF/POI/cargodepotalt.yml
+++ b/Resources/Maps/_NF/POI/cargodepotalt.yml
@@ -55,6 +55,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: BecomesStation
       id: CargoDepotAlt
     - type: DecalGrid

--- a/Resources/Maps/_NF/POI/caseyscasino.yml
+++ b/Resources/Maps/_NF/POI/caseyscasino.yml
@@ -53,6 +53,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -158,6 +158,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/grifty.yml
+++ b/Resources/Maps/_NF/POI/grifty.yml
@@ -46,6 +46,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/lodge.yml
+++ b/Resources/Maps/_NF/POI/lodge.yml
@@ -123,6 +123,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/mchobo.yml
+++ b/Resources/Maps/_NF/POI/mchobo.yml
@@ -57,6 +57,7 @@ entities:
     - type: SpreaderGrid
     - type: Shuttle
     - type: GridPathfinding
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -146,6 +146,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/trade.yml
+++ b/Resources/Maps/_NF/POI/trade.yml
@@ -187,6 +187,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_NF/POI/trademall.yml
+++ b/Resources/Maps/_NF/POI/trademall.yml
@@ -199,6 +199,7 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: NoGridImpacts # Exodus-No-Ram-POI
     - type: GridAtmosphere
       version: 2
       data:


### PR DESCRIPTION
## Описание
Убрана возможность тарана у основных точек интереса. Как по мне это дико, что точка интереса может быть сломана, так и еще возможно пожевывание картонных шлюзов (которые любят отломиться так, что даже срдшкой их быстро непочинишь), из-за чего мне кажется лучше вернуть их отсутвие физики как у колоссус централа (хотя возможно стоит подумать насчет этого у фалькона и гелиоса, мб им это и не надо).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Points of Interest (POI) configurations across multiple maps in Mono and NF regions with standardized impact behavior settings.
  * Modified 20+ map resource files with entity configuration updates.
  * Changes impact how in-game environments handle physical interactions and collision responses.
  * Configuration adjustments applied consistently across all affected locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->