### PR TITLE
Examinable Stealth

### DIFF
--- a/Content.Shared/_Exodus/Stealth/Systems/SharedStealthSystem.cs
+++ b/Content.Shared/_Exodus/Stealth/Systems/SharedStealthSystem.cs
@@ -25,37 +25,8 @@ public abstract class SharedStealthSystem : EntitySystem
         SubscribeLocalEvent<StealthComponent, GetVisibilityModifiersEvent>(OnGetVisibilityModifiers);
         SubscribeLocalEvent<StealthComponent, EntityUnpausedEvent>(OnUnpaused);
         SubscribeLocalEvent<StealthComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<StealthComponent, ExamineAttemptEvent>(OnExamineAttempt);
         SubscribeLocalEvent<StealthComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<StealthComponent, MobStateChangedEvent>(OnMobStateChanged);
-    }
-
-    private void OnExamineAttempt(EntityUid uid, StealthComponent component, ExamineAttemptEvent args)
-    {
-        if (IsVisible(uid))
-            return;
-
-        if (!TryGetMinVisibilityData(uid, out var data))
-            return;
-
-        if (data != null)
-        {
-            if (GetVisibility(uid, component) > data.ExamineThreshold)
-                return;
-
-            // Don't block examine for owner or children of the cloaked entity.
-            // Containers and the like should already block examining, so not bothering to check for occluding containers.
-            var source = args.Examiner;
-            do
-            {
-                if (source == uid)
-                    return;
-                source = Transform(source).ParentUid;
-            }
-            while (source.IsValid());
-
-            args.Cancel();
-        }
     }
 
     private void OnExamined(EntityUid uid, StealthComponent component, ExaminedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a restriction that prevented examining cloaked or invisible entities. Players can now examine these entities without limitations, while other stealth mechanics remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->