### PR TITLE
[FIX] Ahelp window size fix

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -3,14 +3,17 @@
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <PanelContainer StyleClasses="BackgroundDark">
         <SplitContainer Orientation="Horizontal" VerticalExpand="True">
-            <cc:PlayerListControl Access="Public" Name="ChannelSelector" HorizontalExpand="True" SizeFlagsStretchRatio="1" />
+            <!-- SS220-ahelp-channel-selector-fix -->
+            <cc:PlayerListControl Access="Public" Name="ChannelSelector" HorizontalExpand="True" SizeFlagsStretchRatio="1" MinWidth="100" />
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">
-                <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True" />
-                <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+                <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True"/>
+                <!-- SS220-ahelp-window-fix-bgn -->
+                <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5,5,0,5">
                     <CheckBox Name="AdminOnly" Access="Public" Text="{Loc 'admin-ahelp-admin-only'}" ToolTip="{Loc 'admin-ahelp-admin-only-tooltip'}" />
+                    <CheckBox Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" Margin="5,0,0,0"/>
                     <Control HorizontalExpand="True" MinWidth="5" />
-                    <CheckBox Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" />
-                    <Control HorizontalExpand="True" MinWidth="5" />
+                </BoxContainer>
+                <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                     <Button Visible="True" Name="PopOut" Access="Public" Text="{Loc 'admin-logs-pop-out'}" StyleClasses="OpenBoth" HorizontalAlignment="Left" />
                     <Control HorizontalExpand="True" />
                     <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />
@@ -20,6 +23,7 @@
                     <Button Visible="False" Name="Respawn" Text="{Loc 'admin-player-actions-respawn'}" StyleClasses="OpenBoth" />
                     <Button Visible="False" Name="Follow" Text="{Loc 'admin-player-actions-follow'}" StyleClasses="OpenLeft" />
                 </BoxContainer>
+                <!-- SS220-ahelp-window-fix-end -->
             </BoxContainer>
         </SplitContainer>
     </PanelContainer>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -3,11 +3,11 @@
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <PanelContainer StyleClasses="BackgroundDark">
         <SplitContainer Orientation="Horizontal" VerticalExpand="True">
-            <!-- SS220-ahelp-channel-selector-fix -->
+            <!-- Exodus-ahelp-channel-selector-fix -->
             <cc:PlayerListControl Access="Public" Name="ChannelSelector" HorizontalExpand="True" SizeFlagsStretchRatio="1" MinWidth="100" />
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">
                 <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True"/>
-                <!-- SS220-ahelp-window-fix-bgn -->
+                <!-- Exodus-ahelp-window-fix-bgn -->
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5,5,0,5">
                     <CheckBox Name="AdminOnly" Access="Public" Text="{Loc 'admin-ahelp-admin-only'}" ToolTip="{Loc 'admin-ahelp-admin-only-tooltip'}" />
                     <CheckBox Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" Margin="5,0,0,0"/>
@@ -23,7 +23,7 @@
                     <Button Visible="False" Name="Respawn" Text="{Loc 'admin-player-actions-respawn'}" StyleClasses="OpenBoth" />
                     <Button Visible="False" Name="Follow" Text="{Loc 'admin-player-actions-follow'}" StyleClasses="OpenLeft" />
                 </BoxContainer>
-                <!-- SS220-ahelp-window-fix-end -->
+                <!-- Exodus-ahelp-window-fix-end -->
             </BoxContainer>
         </SplitContainer>
     </PanelContainer>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -4,6 +4,6 @@
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >
-                <!-- SS220-minsize-windos-fix -->
+                <!-- SS220-minsize-windows-fix -->
     <cc:BwoinkControl Name="Bwoink" Access="Public"/>
 </DefaultWindow>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -4,6 +4,6 @@
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >
-                <!-- SS220-minsize-windows-fix -->
+                <!-- Exodus-minsize-windows-fix -->
     <cc:BwoinkControl Name="Bwoink" Access="Public"/>
 </DefaultWindow>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -1,8 +1,9 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:cc="clr-namespace:Content.Client.Administration.UI.Bwoink"
-            SetSize="900 500"
+            MinSize="900 500"
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >
+                <!-- SS220-minsize-windos-fix -->
     <cc:BwoinkControl Name="Bwoink" Access="Public"/>
 </DefaultWindow>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Улучшаем внешний вид окна ahelp'а.
Сам размер окна в целом изменён с жесткого SetSize на MinSize, чтобы в случае недостаточности оно автоматически расширялось.

Для панели списка игроков установлена минимальная ширина в сотню, чтобы у окна даже мысли не было сжимать его.
Так как кнопки под полем ввода выглядели немного несуразно и накладывались друг на друга, помимо расширения, они разбиты на два отдельных боксконтейнера друг под дружку. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Хорошо когда удобно

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1911" height="976" alt="image" src="https://github.com/user-attachments/assets/f97c2162-ada6-4c9a-9fa1-9b7a275d837a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Зайти, открыть окно ахелпа, порадоваться

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Таких нет

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Исправлена зажатость Ahelp окна администратора.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Administration window is now resizable with a minimum size of 900×500.
  * Player list/selector maintains a more consistent minimum width for better alignment.
  * Audio/notification controls have improved layout and spacing for clearer presentation.
  * Sound toggle for incoming alerts is enabled by default for immediate feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->