### PR TITLE
FIX: Correct announce Expeditions, auto completed expeditions

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -120,7 +120,17 @@ public sealed partial class SalvageSystem
         var directionLocalization = ContentLocalizationManager.FormatDirection(component.DungeonLocation.GetDir()).ToLower();
 
         if (component.DungeonLocation != Vector2.Zero)
+        {
             Announce(args.MapUid, Loc.GetString("salvage-expedition-announcement-dungeon", ("direction", directionLocalization)));
+
+            // Exodus fix announce expeditions start
+            var mission = GetMission(component.MissionParams.MissionType,
+                component.MissionParams.Difficulty,
+                component.MissionParams.Seed);
+
+            Announce(args.MapUid, GetMissionDescription(mission));
+            // Exodus fix announce expeditions end
+        }
 
         component.Stage = ExpeditionStage.Running;
         Dirty(args.MapUid, component);
@@ -283,6 +293,11 @@ public sealed partial class SalvageSystem
             if (comp.Completed)
                 continue;
 
+            // Exodus fix announce expeditions start
+            if (comp.Stage is ExpeditionStage.Added)
+                continue;
+            // Exodus fix announce expeditions end
+
             var structureAnnounce = false;
 
             for (var i = 0; i < structure.Structures.Count; i++)
@@ -314,6 +329,11 @@ public sealed partial class SalvageSystem
         {
             if (comp.Completed)
                 continue;
+
+            // Exodus fix announce expeditions start
+            if (comp.Stage is ExpeditionStage.Added)
+                continue;
+            // Exodus fix announce expeditions end
 
             var announce = false;
 


### PR DESCRIPTION
## About the PR

Теперь при прилете на экспу отображается кол-во целей для убийства, и при уничтожении одной из них отображается кол-во оставшихся. Так же пофикшено авто выполнение экспы.

(close: https://github.com/SerbiaStrong-220/DevTeamEXDS/issues/39)
(close: https://github.com/SerbiaStrong-220/DevTeamEXDS/issues/56)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="455" height="213" alt="image" src="https://github.com/user-attachments/assets/db7f5da2-49f8-483d-b2eb-e46315c52a5c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
