### PR TITLE
Mech fix/nerf.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -366,7 +366,7 @@
     autoRechargePause: true
     autoRechargePauseTime: 30 # Prevent continuous fire, but not a huge delay
     autoRecharge: true
-    autoRechargeRate: 30 # 4 minutes to fully recharge, 2.5x recharge rate of micro-reactor
+    autoRechargeRate: 12 # 10 minutes to fully recharge, same recharge rate as micro-reactor #Exodus-Mech-Fix
 
 - type: entity
   id: PowerCageHigh

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -366,7 +366,7 @@
     autoRechargePause: true
     autoRechargePauseTime: 30 # Prevent continuous fire, but not a huge delay
     autoRecharge: true
-    autoRechargeRate: 12 # 10 minutes to fully recharge, same recharge rate as micro-reactor #Exodus-Mech-Fix
+    autoRechargeRate: 12 # 10 minutes to fully recharge, same recharge rate as micro-reactor # Exodus-Mech-Fix
 
 - type: entity
   id: PowerCageHigh

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -122,7 +122,7 @@
         Structural: 250
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Minibomb #Exodus-Mech-Fix
+    explosionType: Minibomb # Exodus-Mech-Fix
     maxIntensity: 15
     intensitySlope: 20
     totalIntensity: 15
@@ -169,7 +169,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Minibomb #Exodus-Mech-Fix
+    explosionType: Minibomb # Exodus-Mech-Fix
     totalIntensity: 200
     intensitySlope: 4
     maxIntensity: 100
@@ -342,7 +342,7 @@
     color: "#FF0040"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Minibomb #Exodus-Mech-Fix
+    explosionType: Minibomb # Exodus-Mech-Fix
     totalIntensity: 25
     intensitySlope: 12
     maxIntensity: 15

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -122,7 +122,7 @@
         Structural: 250
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: Minibomb #Exodus-Mech-Fix
     maxIntensity: 15
     intensitySlope: 20
     totalIntensity: 15
@@ -169,7 +169,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: Minibomb #Exodus-Mech-Fix
     totalIntensity: 200
     intensitySlope: 4
     maxIntensity: 100
@@ -342,7 +342,7 @@
     color: "#FF0040"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: Minibomb #Exodus-Mech-Fix
     totalIntensity: 25
     intensitySlope: 12
     maxIntensity: 15

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -244,7 +244,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 60
+    baseWeightlessModifier: 35 #Exodus-Mech-Fix
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -358,7 +358,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 50
+    baseWeightlessModifier: 25 #Exodus-Mech-Fix
   - type: Damageable
     damageModifierSet: MechArmorHeavy
   - type: Tag
@@ -479,7 +479,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1
-    baseWeightlessModifier: 50
+    baseWeightlessModifier: 25 #Exodus-Mech-Fix
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -597,7 +597,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.4
     baseSprintSpeed: 0.8
-    baseWeightlessModifier: 45
+    baseWeightlessModifier: 20 #Exodus-Mech-Fix
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -672,7 +672,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1.2
-    baseWeightlessModifier: 75
+    baseWeightlessModifier: 45 #Exodus-Mech-Fix
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -244,7 +244,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 35 #Exodus-Mech-Fix
+    baseWeightlessModifier: 35 # Exodus-Mech-Fix
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -358,7 +358,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 25 #Exodus-Mech-Fix
+    baseWeightlessModifier: 25 # Exodus-Mech-Fix
   - type: Damageable
     damageModifierSet: MechArmorHeavy
   - type: Tag
@@ -479,7 +479,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1
-    baseWeightlessModifier: 25 #Exodus-Mech-Fix
+    baseWeightlessModifier: 25 # Exodus-Mech-Fix
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -597,7 +597,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.4
     baseSprintSpeed: 0.8
-    baseWeightlessModifier: 20 #Exodus-Mech-Fix
+    baseWeightlessModifier: 20 # Exodus-Mech-Fix
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -672,7 +672,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1.2
-    baseWeightlessModifier: 45 #Exodus-Mech-Fix
+    baseWeightlessModifier: 45 # Exodus-Mech-Fix
   - type: Tag
     tags:
     - DoorBumpOpener


### PR DESCRIPTION
Чтобы не повторяться - основано на https://discord.com/channels/1097181193939730453/1496421785397231697
Расследование причин имбовости мехов ниже в коментах я привёл со скринами и видео.

Тяжёлые пушки мехов наносят примерно 7х урон от того, что задумано. 
Просто чтобы было понятно:
Сейчас плазма сносит укреп пластитановую стену за 3 выстрела. (сам снаряд наносит 200 урона, а взрыв который он создаёт ещё 1000)
Скорострельность 3 в секунду. 
Максимальный заряд батари позволяет сделать 72 выстрела, ака вести огонь ~20 секунд без остановки. Это позволяет снести ~20 пластитановых стен, обычно у шаттлов 2-3 стены до дама. Вот и думайте почему мехи определяют исход войны каждый раунд. Можно 2 часа в поте лица готовить шаттл к бою, пушки там ставить, двигатели, стены укреплять, чтобы потом прилетел мех сделанный за 2 копейки за 3 минуты и бахнул твой шаттл. 
При этом мехи летают со скоростью, не позволяющей их сбить из-за задержки сканера масс (видео я приложил там в треде дискорда, сюда не лезет). Единственный способ убить меха - чудовищная ошибка его пилота.

Короче внесены исправления:
Исправил огромный урон от взрывов снарядов пушек мехов. 
Убавил скорость самозарядки батарейки мехов до значений микрореакторки. Теперь после отстрела всего заряда нужно либо лететь на базу заряжаться, либо подольше летать вне боя. Авианосцы заимеют смысл, ибо сейчас мехи вообще не возвращаются на базу никогда, им это не нужно. 
Убавил максимальную скорость полёта мехам, они стабильно летали быстрее шаттлов, быстрее некоторых снарядов и попасть в них виртуально невозможно, на практике только случайно или если пилот вылетит из игры. 

https://github.com/user-attachments/assets/abcc9a9a-1a4e-4088-8eaa-38f60fcac029

Во, урон плазмы, это я медленно стрелял чтобы точно было понятно сколько выстрелов сделано.





## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

:cl: Lancevrot
- tweak: Понижена скорость самозарядки батареи мехов до значения микрореакторной. 
- tweak: Понижена максимальная скорость полёта мехов. 
- fix: Исправлен недочёт, из-за которого тяжелое вооружение мехов наносило примерно семикратный урон от задуманного.