### PR TITLE
Fix: Hitscan fix for AI's

### DIFF
--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -4,6 +4,8 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Database;
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Containers;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
@@ -13,6 +15,7 @@ namespace Content.Shared.Weapons.Hitscan.Systems;
 public sealed class HitscanBasicRaycastSystem : EntitySystem
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly ISharedAdminLogManager _log = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
@@ -26,20 +29,16 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
     private void OnHitscanFired(Entity<HitscanBasicRaycastComponent> ent, ref HitscanTraceEvent args)
     {
         var gun = args.Gun; // Exodus-hitscan-ai-fix
+        var gunComp = Comp<GunComponent>(gun);
         var shooter = args.Shooter ?? args.Gun;
         var mapCords = _transform.ToMapCoordinates(args.FromCoordinates);
         var ray = new CollisionRay(mapCords.Position, args.ShotDirection, (int) ent.Comp.CollisionMask);
-        var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooter, false);
-
-        var target = args.Target;
         var shooterOrGun = gunComp.UseUserPosition ? shooter : args.Gun;
         var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooterOrGun, false);
         var target = args.Target;
         var result = _container.IsEntityOrParentInContainer(shooterOrGun)
             ? rayCastResults.FirstOrNull()
             : rayCastResults.FirstOrNull(hit => hit.HitEntity == target || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true);
-                                                       (hit.HitEntity == target
-                                                       || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true));
 
         var trace = new HitscanRaycastFiredEvent
         {

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -39,8 +39,10 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
         //  1.) Hit the first entity that you targeted.
         //  2.) Hit the first entity that doesn't require you to aim at it specifically to be hit.
         var result = _container.IsEntityOrParentInContainer(shooter)
-            ? rayCastResults.FirstOrNull()
-            : rayCastResults.FirstOrNull(hit => hit.HitEntity != gun && // Exodus: ensure the gun itself is skipped
+            ? rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
+                                                (hit.HitEntity == target
+                                                || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true))
+            : rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
                                                 (hit.HitEntity == target
                                                 || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true));
 

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -4,7 +4,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Database;
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
-using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Components; // Exodus
 using Robust.Shared.Containers;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -28,17 +28,17 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
 
     private void OnHitscanFired(Entity<HitscanBasicRaycastComponent> ent, ref HitscanTraceEvent args)
     {
-        var gun = args.Gun; // Exodus-hitscan-ai-fix
-        var gunComp = Comp<GunComponent>(gun);
+        var gun = args.Gun; // Exodus
+        var gunComp = Comp<GunComponent>(gun); // Exodus
         var shooter = args.Shooter ?? args.Gun;
         var mapCords = _transform.ToMapCoordinates(args.FromCoordinates);
         var ray = new CollisionRay(mapCords.Position, args.ShotDirection, (int) ent.Comp.CollisionMask);
-        var shooterOrGun = gunComp.UseUserPosition ? shooter : args.Gun;
-        var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooterOrGun, false);
+        var shooterOrGun = gunComp.UseUserPosition ? shooter : args.Gun; // Exodus
+        var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooterOrGun, false); // Exodus
         var target = args.Target;
-        var result = _container.IsEntityOrParentInContainer(shooterOrGun)
+        var result = _container.IsEntityOrParentInContainer(shooterOrGun) // Exodus
             ? rayCastResults.FirstOrNull()
-            : rayCastResults.FirstOrNull(hit => hit.HitEntity == target || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true);
+            : rayCastResults.FirstOrNull(hit => hit.HitEntity == target || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true); // Exodus
 
         var trace = new HitscanRaycastFiredEvent
         {

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -32,7 +32,12 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
         var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooter, false);
 
         var target = args.Target;
-        var result = rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
+        var shooterOrGun = gunComp.UseUserPosition ? shooter : args.Gun;
+        var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooterOrGun, false);
+        var target = args.Target;
+        var result = _container.IsEntityOrParentInContainer(shooterOrGun)
+            ? rayCastResults.FirstOrNull()
+            : rayCastResults.FirstOrNull(hit => hit.HitEntity == target || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true);
                                                        (hit.HitEntity == target
                                                        || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true));
 

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Database;
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
-using Robust.Shared.Containers;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
@@ -14,7 +13,6 @@ namespace Content.Shared.Weapons.Hitscan.Systems;
 public sealed class HitscanBasicRaycastSystem : EntitySystem
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly ISharedAdminLogManager _log = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
@@ -27,24 +25,16 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
 
     private void OnHitscanFired(Entity<HitscanBasicRaycastComponent> ent, ref HitscanTraceEvent args)
     {
-        var gun = args.Gun; // Exodus: for usage in lamda later
+        var gun = args.Gun; // Exodus-hitscan-ai-fix
         var shooter = args.Shooter ?? args.Gun;
         var mapCords = _transform.ToMapCoordinates(args.FromCoordinates);
         var ray = new CollisionRay(mapCords.Position, args.ShotDirection, (int) ent.Comp.CollisionMask);
         var rayCastResults = _physics.IntersectRay(mapCords.MapId, ray, ent.Comp.MaxDistance, shooter, false);
 
         var target = args.Target;
-        // If you are in a container, use the raycast result
-        // Otherwise:
-        //  1.) Hit the first entity that you targeted.
-        //  2.) Hit the first entity that doesn't require you to aim at it specifically to be hit.
-        var result = _container.IsEntityOrParentInContainer(shooter)
-            ? rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
-                                                (hit.HitEntity == target
-                                                || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true))
-            : rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
-                                                (hit.HitEntity == target
-                                                || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true));
+        var result = rayCastResults.FirstOrNull(hit => hit.HitEntity != gun &&
+                                                       (hit.HitEntity == target
+                                                       || CompOrNull<RequireProjectileTargetComponent>(hit.HitEntity)?.Active != true));
 
         var trace = new HitscanRaycastFiredEvent
         {


### PR DESCRIPTION
## Описание PR
Исправлена стрельба корабельных hitscan-орудий через gunnery console для игроков на ролях ядер ИИ.
Теперь при управлении орудиями на роли ИИ-ядра выстрелы больше не задевают собственные пушки / корпус корабля из-за некорректной обработки shooter, находящегося в контейнере.
Стенки которые мешают стрельбе не игнорируются.

## Почему / Баланс
Ранее ИИ-игрок на АДС и похожих ИИ-ролях ролях мог при стрельбе из hitscan-орудий фактически ломать свой же корабль вместо нормальной стрельбы по цели.

## Технические детали
Изменение внесено в HitscanBasicRaycastSystem.cs в ветку обработки hitscan для shooter, находящегося в контейнере.
Добавлена такая же фильтрация попаданий, как и в обычной ветке raycast:
1. Игнорируется сама пушка (gun)
2. Сохраняется корректная проверка цели / RequireProjectileTarget

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

