### PR TITLE
Feat: New Combatant Department for ghostroles spawn.

### DIFF
--- a/Resources/Locale/en-US/_NF/job/department.ftl
+++ b/Resources/Locale/en-US/_NF/job/department.ftl
@@ -3,3 +3,4 @@ department-Antag = Phaethon Dynasty Imperial Vanguard
 department-Command = Central Command
 department-Frontier = Colossus Frontier Colonization
 department-Security = TSF Marine Corps Detachment
+department-Combatant = Combatant

--- a/Resources/Locale/ru-RU/_NF/job/department.ftl
+++ b/Resources/Locale/ru-RU/_NF/job/department.ftl
@@ -3,3 +3,4 @@ department-Antag = Авангард Династии Фаэтона
 department-Command = Командование Сектора
 department-Frontier = Сотрудники Аванпоста
 department-Security = Корпус Военной Полиции ТСФ
+department-Combatant = Комбатанты

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -137,23 +137,16 @@
   primary: false
   editorHidden: true
   roles:
-  - PrisonGuard
-  - Brigmedic
-  - NFDetective
   - Cadet
   - Deputy
   - Bailiff
   - Sheriff
   - SeniorOfficer
-  - PublicAffairsLiaison
-  - TsfEngineer
-  - TsfBorg
   - Pirate
   - PirateFirstMate
   - PirateCaptain
   - PDVDenasvar
   - PDVInfiltrator
-  - PdvBorg
 
 - type: department
   id: Science

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -128,6 +128,33 @@
   - TsfBorg # Mono
 
 - type: department
+  id: Combatant
+  name: department-Security
+  description: department-NFSecurity-description # Frontier
+  color: "#326DA8"
+  weight: 120
+  primary: false
+  editorHidden: true
+  roles:
+  - PrisonGuard
+  - Brigmedic
+  - NFDetective
+  - Cadet
+  - Deputy
+  - Bailiff
+  - Sheriff
+  - SeniorOfficer
+  - PublicAffairsLiaison
+  - TsfEngineer
+  - TsfBorg
+  - Pirate
+  - PirateFirstMate
+  - PirateCaptain
+  - PDVDenasvar
+  - PDVInfiltrator
+  - PdvBorg
+
+- type: department
   id: Science
   name: department-Science
   description: department-Science-description

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -127,9 +127,10 @@
   - TsfEngineer # Mono
   - TsfBorg # Mono
 
+# Exodus
 - type: department
   id: Combatant
-  name: department-Security
+  name: department-Combatant
   description: department-NFSecurity-description # Frontier
   color: "#326DA8"
   weight: 120

--- a/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
@@ -29,7 +29,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 2
+      minDepartmentPlayers: 3
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -49,7 +49,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 2
+      minDepartmentPlayers: 3
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -69,7 +69,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 2
+      minDepartmentPlayers: 3
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -89,7 +89,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 2
+      minDepartmentPlayers: 3
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -109,7 +109,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -129,4 +129,4 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7

--- a/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
@@ -28,7 +28,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 2
 
 - type: entity
@@ -48,7 +48,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 2
 
 - type: entity
@@ -68,7 +68,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 2
 
 - type: entity
@@ -88,7 +88,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 2
 
 - type: entity
@@ -108,7 +108,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -128,5 +128,5 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6

--- a/Resources/Prototypes/_Mono/GameRules/asakim.yml
+++ b/Resources/Prototypes/_Mono/GameRules/asakim.yml
@@ -22,7 +22,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -42,5 +42,5 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 8

--- a/Resources/Prototypes/_Mono/GameRules/chimera.yml
+++ b/Resources/Prototypes/_Mono/GameRules/chimera.yml
@@ -25,7 +25,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -45,7 +45,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -65,7 +65,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -85,5 +85,5 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 

--- a/Resources/Prototypes/_Mono/GameRules/chimera.yml
+++ b/Resources/Prototypes/_Mono/GameRules/chimera.yml
@@ -24,7 +24,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -44,7 +44,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -64,7 +64,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -84,6 +84,6 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -35,7 +35,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -55,7 +55,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -75,7 +75,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -95,7 +95,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 2
+      minDepartmentPlayers: 3
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -115,7 +115,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 6
+      minDepartmentPlayers: 7
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -135,4 +135,4 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 8
+      minDepartmentPlayers: 9

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -34,7 +34,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -54,7 +54,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -74,7 +74,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -94,7 +94,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 2
 
 - type: entity
@@ -114,7 +114,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 6
 
 - type: entity
@@ -134,5 +134,5 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 8

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -42,7 +42,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 4
 
 - type: entity
@@ -87,7 +87,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 4
 
 - type: entity
@@ -133,7 +133,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 4
 
 - type: entity
@@ -177,7 +177,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 4
 
 # Mono edit - Mono UIV's
@@ -213,7 +213,7 @@
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
-      department: Security
+      department: Combatant
       minDepartmentPlayers: 4
 # Mono edit end
 

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -43,7 +43,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 4
+      minDepartmentPlayers: 5
 
 - type: entity
   id: BluespaceVaultError
@@ -88,7 +88,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 4
+      minDepartmentPlayers: 5
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -134,7 +134,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 4
+      minDepartmentPlayers: 5
 
 - type: entity
   id: BluespaceSyndicateFTLInterception
@@ -178,7 +178,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 4
+      minDepartmentPlayers: 5
 
 # Mono edit - Mono UIV's
 - type: entity
@@ -214,7 +214,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 4
+      minDepartmentPlayers: 5
 # Mono edit end
 
 ## Mono edit - commenting out useless UIV's


### PR DESCRIPTION
## Описание PR
Добавил новую фракцию - Combatant. Фракция, которая объединяет и ДФ и ТСФ. Заменил фракцию Security (только ТСФ) на Combatant при подсчете режима активных игроков для условия спавна определенных ролей.

## Почему / Баланс
ТСФ и ДФ де-факто основные стороны конфликта и могут регулировать космос и ставить свои законы и условия. В случае победы ДФ над ТСФ, большинство гостролей не спавнится т.к. ТСФ перебито, объединил их в одну фракцию в контексте подсчета количества активных игроков-комбатантов для спавна ролей и гост-антагов.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.