### PR TITLE
Fix: AI can't control no-energy borgs

### DIFF
--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -49,8 +49,6 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         SubscribeLocalEvent<AiRemoteControllerComponent, ReturnMindIntoAiEvent>(OnReturnMindIntoAi);
         SubscribeLocalEvent<AiRemoteControllerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AiRemoteControllerComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<AiRemoteControllerComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty); // Exodus ai-remote-power-check
-        SubscribeLocalEvent<AiRemoteControllerComponent, PowerCellChangedEvent>(OnPowerCellChanged); // Exodus ai-remote-power-check
         SubscribeLocalEvent<AiRemoteControllerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<StationAiHeldComponent, AiRemoteControllerComponent.RemoteDeviceActionMessage>(OnUiRemoteAction);
         SubscribeLocalEvent<StationAiHeldComponent, ToggleRemoteDevicesScreenEvent>(OnToggleRemoteDevicesScreen);
@@ -104,27 +102,6 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         ReturnMindIntoAi(entity);
 
     // Exodus-begin ai-remote-power-check
-    private void OnPowerCellSlotEmpty(Entity<AiRemoteControllerComponent> entity, ref PowerCellSlotEmptyEvent args)
-    {
-        if (entity.Comp.AiHolder == null)
-            return;
-
-        SendAiRemoteChat(entity, "ai-remote-control-lost-power");
-        ReturnMindIntoAi(entity);
-    }
-
-    private void OnPowerCellChanged(Entity<AiRemoteControllerComponent> entity, ref PowerCellChangedEvent args)
-    {
-        if (entity.Comp.AiHolder == null)
-            return;
-
-        if (HasRemotePower(entity, out _))
-            return;
-
-        SendAiRemoteChat(entity, "ai-remote-control-lost-power");
-        ReturnMindIntoAi(entity);
-    }
-
     private bool HasRemotePower(EntityUid entity, out string? failMessage)
     {
         failMessage = null;

--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -105,9 +105,10 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
     // Exodus-begin ai-remote-power-check
     private void OnPowerCellSlotEmpty(Entity<AiRemoteControllerComponent> entity, ref PowerCellSlotEmptyEvent args)
     {
-        if (entity.Comp.AiHolder != null)
-            SendAiRemoteChat(entity, "ai-remote-control-lost-power");
+        if (entity.Comp.AiHolder == null)
+            return;
 
+        SendAiRemoteChat(entity, "ai-remote-control-lost-power");
         ReturnMindIntoAi(entity);
     }
 

--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -50,6 +50,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         SubscribeLocalEvent<AiRemoteControllerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AiRemoteControllerComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<AiRemoteControllerComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty); // Exodus ai-remote-power-check
+        SubscribeLocalEvent<AiRemoteControllerComponent, PowerCellChangedEvent>(OnPowerCellChanged); // Exodus ai-remote-power-check
         SubscribeLocalEvent<AiRemoteControllerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<StationAiHeldComponent, AiRemoteControllerComponent.RemoteDeviceActionMessage>(OnUiRemoteAction);
         SubscribeLocalEvent<StationAiHeldComponent, ToggleRemoteDevicesScreenEvent>(OnToggleRemoteDevicesScreen);
@@ -112,6 +113,18 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         ReturnMindIntoAi(entity);
     }
 
+    private void OnPowerCellChanged(Entity<AiRemoteControllerComponent> entity, ref PowerCellChangedEvent args)
+    {
+        if (entity.Comp.AiHolder == null)
+            return;
+
+        if (HasRemotePower(entity, out _))
+            return;
+
+        SendAiRemoteChat(entity, "ai-remote-control-lost-power");
+        ReturnMindIntoAi(entity);
+    }
+
     private bool HasRemotePower(EntityUid entity, out string? failMessage)
     {
         failMessage = null;
@@ -126,7 +139,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
             return false;
         }
 
-        if (battery.CurrentCharge >= draw.DrawRate)
+        if (battery.CurrentCharge > 0f && battery.CurrentCharge >= draw.DrawRate)
             return true;
 
         failMessage = "ai-remote-control-insufficient-power";

--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -7,11 +7,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Radio.Components;
+using Content.Server.PowerCell; // Exodus ai-remote-power-check
+using Content.Shared.PowerCell.Components; // Exodus ai-remote-power-check
+using Content.Server.Chat.Managers; // Exodus ai-remote-power-check
 using Content.Server.Silicons.Laws;
 using Content.Shared._CorvaxNext.Silicons.Borgs;
 using Content.Shared._CorvaxNext.Silicons.Borgs.Components;
 using Content.Shared.Actions;
+using Content.Shared.Chat; // Exodus ai-remote-power-check
+using Content.Shared.IdentityManagement; // Exodus ai-remote-power-check
 using Content.Shared.Mind;
+using Content.Shared.PowerCell; // Exodus ai-remote-power-check
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.StationAi;
@@ -29,6 +35,8 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
     [Dependency] private readonly SiliconLawSystem _lawSystem = default!;
     [Dependency] private readonly SharedStationAiSystem _stationAiSystem = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly PowerCellSystem _powerCell = default!; // Exodus ai-remote-power-check
+    [Dependency] private readonly IChatManager _chatManager = default!; // Exodus ai-remote-power-check
     [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
 
@@ -41,6 +49,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         SubscribeLocalEvent<AiRemoteControllerComponent, ReturnMindIntoAiEvent>(OnReturnMindIntoAi);
         SubscribeLocalEvent<AiRemoteControllerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AiRemoteControllerComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<AiRemoteControllerComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty); // Exodus ai-remote-power-check
         SubscribeLocalEvent<AiRemoteControllerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<StationAiHeldComponent, AiRemoteControllerComponent.RemoteDeviceActionMessage>(OnUiRemoteAction);
         SubscribeLocalEvent<StationAiHeldComponent, ToggleRemoteDevicesScreenEvent>(OnToggleRemoteDevicesScreen);
@@ -93,6 +102,50 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
     private void OnReturnMindIntoAi(Entity<AiRemoteControllerComponent> entity, ref ReturnMindIntoAiEvent args) =>
         ReturnMindIntoAi(entity);
 
+    // Exodus-begin ai-remote-power-check
+    private void OnPowerCellSlotEmpty(Entity<AiRemoteControllerComponent> entity, ref PowerCellSlotEmptyEvent args)
+    {
+        if (entity.Comp.AiHolder != null)
+            SendAiRemoteChat(entity, "ai-remote-control-lost-power");
+
+        ReturnMindIntoAi(entity);
+    }
+
+    private bool HasRemotePower(EntityUid entity, out string? failMessage)
+    {
+        failMessage = null;
+
+        if (!TryComp<PowerCellDrawComponent>(entity, out var draw)
+            || !TryComp<PowerCellSlotComponent>(entity, out var slot))
+            return true;
+
+        if (!_powerCell.TryGetBatteryFromSlot(entity, out var battery, slot))
+        {
+            failMessage = "ai-remote-control-no-power-cell";
+            return false;
+        }
+
+        if (battery.CurrentCharge >= draw.DrawRate)
+            return true;
+
+        failMessage = "ai-remote-control-insufficient-power";
+        return false;
+    }
+
+    private void SendAiRemoteChat(EntityUid recipient, string locId, EntityUid? borg = null)
+    {
+        if (!TryComp<ActorComponent>(recipient, out var actor))
+            return;
+
+        var msg = Loc.GetString(
+            locId,
+            ("borg", Identity.Name(borg ?? recipient, EntityManager)));
+        var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
+
+        _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel);
+    }
+    // Exodus-end
+
     public void AiTakeControl(EntityUid ai, EntityUid entity)
     {
         if (!_mind.TryGetMind(ai, out var mindId, out var mind))
@@ -109,6 +162,14 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
 
         if (!_map.TryFindGridAt(Transform(ai).MapPosition, out var grid, out var _) || Transform(entity).GridUid != grid)
             return; // Mono no controlling borgs outside the ai's grid.
+
+        // Exodus-begin ai-remote-power-check
+        if (!HasRemotePower(entity, out var failMessage))
+        {
+            SendAiRemoteChat(ai, failMessage!, entity);
+            return;
+        }
+        // Exodus-end
 
         if (TryComp(entity, out IntrinsicRadioTransmitterComponent? transmitter))
         {

--- a/Resources/Locale/en-US/_corvaxnext/silicons/ai-remote.ftl
+++ b/Resources/Locale/en-US/_corvaxnext/silicons/ai-remote.ftl
@@ -5,4 +5,3 @@ ai-remote-control = Take control
 # Exodus ai-remote-power-check
 ai-remote-control-no-power-cell = Cannot remotely control {$borg}: no power cell installed.
 ai-remote-control-insufficient-power = Cannot remotely control {$borg}: insufficient power.
-ai-remote-control-lost-power = Remote control of {$borg} lost: cyborg power depleted.

--- a/Resources/Locale/en-US/_corvaxnext/silicons/ai-remote.ftl
+++ b/Resources/Locale/en-US/_corvaxnext/silicons/ai-remote.ftl
@@ -2,3 +2,7 @@
 ai-remote-ui-menu-title = Available devices
 ai-remote-ui-menu-moveto = Move to
 ai-remote-control = Take control
+# Exodus ai-remote-power-check
+ai-remote-control-no-power-cell = Cannot remotely control {$borg}: no power cell installed.
+ai-remote-control-insufficient-power = Cannot remotely control {$borg}: insufficient power.
+ai-remote-control-lost-power = Remote control of {$borg} lost: cyborg power depleted.

--- a/Resources/Locale/ru-RU/_corvaxnext/silicons/ai-remote.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/silicons/ai-remote.ftl
@@ -1,0 +1,8 @@
+# UI
+ai-remote-ui-menu-title = Доступные устройства
+ai-remote-ui-menu-moveto = Переместиться к
+ai-remote-control = Взять управление
+# Exodus ai-remote-power-check
+ai-remote-control-no-power-cell = Невозможно удалённо управлять боргом {$borg}: батарейка не установлена.
+ai-remote-control-insufficient-power = Невозможно удалённо управлять боргом {$borg}: недостаточно энергии.
+ai-remote-control-lost-power = Удалённое управление боргом {$borg} потеряно: питание борга исчерпано.

--- a/Resources/Locale/ru-RU/_corvaxnext/silicons/ai-remote.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/silicons/ai-remote.ftl
@@ -5,4 +5,3 @@ ai-remote-control = Взять управление
 # Exodus ai-remote-power-check
 ai-remote-control-no-power-cell = Невозможно удалённо управлять боргом {$borg}: батарейка не установлена.
 ai-remote-control-insufficient-power = Невозможно удалённо управлять боргом {$borg}: недостаточно энергии.
-ai-remote-control-lost-power = Удалённое управление боргом {$borg} потеряно: питание борга исчерпано.


### PR DESCRIPTION
## Описание PR
Пофиксил баг, что ИИ мог контролировать боргов без энергии. Добавил механ, что ИИ в принципе не может контролировать боргов без энергии или батарейки. Теперь отсутствие энергии просто выкидывает ИИ-игрока с борга.
Плюсом перевел UI-шку выбора боргов.
UPD: Обсудив в дискорде в https://discord.com/channels/1097181193939730453/1497768741738385489/1497768741738385489 пришли к решению, что лучше оставить возможность ИИ находиться в разряженном борге но невозможно заселиться. Сделано в основном что с помощью ЭМИ пушек можно выбить оператора-ии-борга с корабля, даже если там самозарядная батарея.

## Почему / Баланс
Багфикс

## Медиа
<img width="372" height="207" alt="изображение" src="https://github.com/user-attachments/assets/937b9f50-cba9-4ee8-aa2e-a20a47ed9dcc" />

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.