### PR TITLE
Feat: ADS spawn rebalance

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/Slowed/slowed_schedulers.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Slowed/slowed_schedulers.yml
@@ -7,7 +7,7 @@
       tableId: DamagedAIShipsTable
     minimumTimeUntilFirstEvent: 3600 # 1 hour
     minMaxEventTiming:
-      min: 8100 # 135 minutes between events
+      min: 5400 # 90 minutes between events Exodus-Tweak
       max: 10800 # 180 minutes between events
 
 - type: entity
@@ -17,7 +17,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: DamagedAIShipsTableT2
-    minimumTimeUntilFirstEvent: 14400 # 4 hours
+    minimumTimeUntilFirstEvent: 10800 # 3 hours Exodus-Tweak
     minMaxEventTiming:
       min: 5400 # 90 minutes between events
       max: 5400 # 90 minutes between events

--- a/Resources/Prototypes/_Mono/GameRules/base.yml
+++ b/Resources/Prototypes/_Mono/GameRules/base.yml
@@ -7,7 +7,7 @@
         tableId: DamagedAIShipsTable
       minimumTimeUntilFirstEvent: 3600 # 1 hour
       minMaxEventTiming:
-        min: 5400 # 90 minutes between events
+        min: 3600 # 60 minutes between events Exodus-Tweak
         max: 7200 # 120 minutes between events
 
 - type: entity
@@ -17,7 +17,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: DamagedAIShipsTableT2
-    minimumTimeUntilFirstEvent: 10800 # 3 hours
+    minimumTimeUntilFirstEvent: 7200 # 2 hours Exodus-Tweak
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
       max: 3600 # 60 minutes between events
@@ -32,7 +32,7 @@
     minimumTimeUntilFirstEvent: 3600 # 1 hour
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
-      max: 7200 # 120 minutes between events
+      max: 5400 # 90 minutes between events Exodus-Tweak
 
 - type: entity
   id: MonoChimeraSTCShuttleSpawnerScheduler

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -35,7 +35,7 @@
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 7
+      minDepartmentPlayers: 6
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -68,14 +68,14 @@
     weight: 2
     maxOccurrences: 4
   - type: GameRule
-    minPlayers: 32
+    minPlayers: 26
   - type: LoadMapRule
     gridPath: /Maps/_Exodus/ShuttleEvent/nebula.yml # Exodus-Tweak
   - type: GameRuleRequirements # Exodus
     requirements:
     - !type:JobGameRuleRequirement
       department: Combatant
-      minDepartmentPlayers: 7
+      minDepartmentPlayers: 5
 
 - type: entity
   parent: BaseRandomShuttleRule


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Изменены тайминги спавнов АДС и Азакимов в режиме "наследие" и "смешанный"
Изменены требования к комбатантам у Т1 Зенита и Т1 Небулы.

## Почему / Баланс
**Изменены тайминги base (Наследие).**
(Тайминги спавна Азакимов и АДС изменены, что бы больше соответствовать сути самого режима + снятие ВЛ на АДС увеличило кол-во гостплееров, изменения призваны соответствовать увеличившемуся кол-ву кандидатов на гостроль в пределах режима наследия). 
Изменены тайминги спавна Т1 кораблей. min значение изменено с **90 до 60** минут.
Изменены тайминги спавна Азакимов. max значение изменено с **120 до 90** минут.
Изменены тайминги для Т2 кораблей, инициация спавна начинается с двух часов от начала игры (вместо трёх, как было раньше).

**Изменены тайминги slowed_schedulers (Смешанный).** 
Изменены тайминги спавна Т1 кораблей, значение min сменено с **125 до 90** минут.
Изменены тайминги для Т2 кораблей, инициация спавна изменена с 4 часов до 3 от начала раунда.

**Изменены требования к спауну кораблей в damaged_ai**
Т1 Зенит слишком слабый, что бы требовать 7 комбатантов, опущено до 6.
Т1 Небула это промежуточный корабль, она лишь немногим сильнее вирма, 7 комбатантов это слишком много для такого корабля. Опущено до 5. (так же, изменено мин плеер с 32 до 26, я знаю что оно не работает, но я меняю его на случай, если работать начнёт).

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->
