### PR TITLE
Feat: Wyrm hotfix

### DIFF
--- a/Resources/Maps/_Exodus/ShuttleEvent/wyrm.yml
+++ b/Resources/Maps/_Exodus/ShuttleEvent/wyrm.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2026 13:38:45
-  entityCount: 527
+  time: 04/30/2026 04:13:13
+  entityCount: 529
 maps: []
 grids:
 - 1
@@ -53,7 +53,7 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: BAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAA4AAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAADQAAAAAAAAUAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAABQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAoAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAADwAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAALAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACgAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAsAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEwAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAkAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          tiles: BAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAA4AAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAADQAAAAAAAAUAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAABQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAoAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAADwAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAALAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACgAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAKAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAsAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEwAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAkAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
           version: 7
         0,1:
           ind: 0,1
@@ -61,7 +61,7 @@ entities:
           version: 7
         -1,0:
           ind: -1,0
-          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAADQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAFAAAAAAAAAwAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAFAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAPAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAABAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEQAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAA==
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAADQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAFAAAAAAAAAwAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAFAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAPAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEQAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAA==
           version: 7
         -1,1:
           ind: -1,1
@@ -182,6 +182,119 @@ entities:
     - type: GridAtmosphere
       version: 2
       data:
+        tiles:
+          0,0:
+            0: 4409
+            1: 8192
+          -1,0:
+            0: 32914
+            2: 1
+          0,1:
+            0: 6007
+          -1,1:
+            0: 7372
+          0,2:
+            0: 4531
+            2: 2048
+          -1,2:
+            1: 136
+            0: 33
+            2: 512
+          0,3:
+            0: 4100
+            2: 64
+          0,4:
+            0: 33
+          0,-1:
+            0: 34400
+            2: 142
+          1,0:
+            2: 34913
+            0: 536
+          1,1:
+            0: 4164
+          1,2:
+            0: 3
+          1,-1:
+            2: 4097
+            0: 272
+          -2,0:
+            0: 2050
+            2: 8896
+          -2,1:
+            0: 68
+          -2,2:
+            0: 8
+          -1,-1:
+            2: 4143
+            0: 11728
+          -1,3:
+            1: 4
+            2: 64
+          -1,4:
+            0: 128
+          0,-2:
+            2: 63488
+          -1,-2:
+            2: 57856
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -190,580 +303,585 @@ entities:
     - type: ThermalSignature
 - proto: AirlockHatch
   entities:
-  - uid: 146
+  - uid: 2
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 402
+  - uid: 3
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 19
+  - uid: 4
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 279
+  - uid: 5
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 401
+  - uid: 6
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 23
+  - uid: 7
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 28
+  - uid: 8
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 40
+  - uid: 9
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 47
+  - uid: 10
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 48
+  - uid: 11
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 49
+  - uid: 12
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 52
+  - uid: 13
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 69
+  - uid: 14
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 73
+  - uid: 15
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 74
+  - uid: 16
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 77
+  - uid: 17
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 80
+  - uid: 18
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 106
+  - uid: 19
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 116
+  - uid: 20
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 121
+  - uid: 21
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 122
+  - uid: 22
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 124
+  - uid: 23
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 147
+  - uid: 24
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 152
+  - uid: 25
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 158
+  - uid: 26
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 159
+  - uid: 27
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 160
+  - uid: 28
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 166
+  - uid: 29
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 171
+  - uid: 30
     components:
     - type: Transform
-      pos: 4.5,6.5
+      pos: -3.5,7.5
       parent: 1
-  - uid: 174
+  - uid: 31
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 177
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 178
+  - uid: 33
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 182
+  - uid: 34
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 186
+  - uid: 35
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 187
+  - uid: 36
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 188
+  - uid: 37
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 189
+  - uid: 38
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 190
+  - uid: 39
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 191
+  - uid: 40
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 192
+  - uid: 41
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 193
+  - uid: 42
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 194
+  - uid: 43
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 195
+  - uid: 44
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 196
+  - uid: 45
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 197
+  - uid: 46
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 198
+  - uid: 47
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 200
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 201
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 202
+  - uid: 50
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 203
+  - uid: 51
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 204
+  - uid: 52
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 205
+  - uid: 53
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 206
+  - uid: 54
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 207
+  - uid: 55
     components:
     - type: Transform
-      pos: -3.5,6.5
+      pos: -3.5,8.5
       parent: 1
-  - uid: 208
+  - uid: 56
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 209
+  - uid: 57
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 212
+  - uid: 58
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 214
+  - uid: 59
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 215
+  - uid: 60
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 216
+  - uid: 61
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 229
+  - uid: 62
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 230
+  - uid: 63
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 231
+  - uid: 64
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 232
+  - uid: 65
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 233
+  - uid: 66
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 234
+  - uid: 67
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 235
+  - uid: 68
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 236
+  - uid: 69
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 237
+  - uid: 70
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 238
+  - uid: 71
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-  - uid: 239
+  - uid: 72
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 240
+  - uid: 73
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 241
+  - uid: 74
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 242
+  - uid: 75
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 243
+  - uid: 76
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 244
+  - uid: 77
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 245
+  - uid: 78
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 247
+  - uid: 79
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 248
+  - uid: 80
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 249
+  - uid: 81
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 252
+  - uid: 82
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 288
+  - uid: 83
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 294
+  - uid: 84
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 311
+  - uid: 85
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 312
+  - uid: 86
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 323
+  - uid: 87
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 335
+  - uid: 88
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 342
+  - uid: 89
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 343
+  - uid: 90
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 344
+  - uid: 91
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 346
+  - uid: 92
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 351
+  - uid: 93
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 358
+  - uid: 94
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 360
+  - uid: 95
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 362
+  - uid: 96
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 363
+  - uid: 97
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 364
+  - uid: 98
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 365
+  - uid: 99
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 366
+  - uid: 100
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 367
+  - uid: 101
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 368
+  - uid: 102
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 369
+  - uid: 103
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 370
+  - uid: 104
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 371
+  - uid: 105
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 372
+  - uid: 106
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 373
+  - uid: 107
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 518
+  - uid: 108
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 519
+  - uid: 109
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 520
+  - uid: 110
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 523
+  - uid: 111
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 524
+  - uid: 112
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 525
+  - uid: 113
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 67
+  - uid: 115
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 70
+  - uid: 116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -771,698 +889,698 @@ entities:
       parent: 1
 - proto: BorgCharger
   entities:
-  - uid: 145
+  - uid: 117
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 516
+  - uid: 118
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 517
+  - uid: 119
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 21
+  - uid: 120
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 41
+  - uid: 121
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 50
+  - uid: 122
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 51
+  - uid: 123
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 54
+  - uid: 124
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 59
+  - uid: 125
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 83
+  - uid: 126
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 108
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 111
+  - uid: 128
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 135
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 253
+  - uid: 130
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
-  - uid: 280
+  - uid: 131
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 281
+  - uid: 132
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 282
+  - uid: 133
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 284
+  - uid: 134
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 289
+  - uid: 135
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 290
+  - uid: 136
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 291
+  - uid: 137
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 292
+  - uid: 138
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 293
+  - uid: 139
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 297
+  - uid: 140
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 298
+  - uid: 141
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 299
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 300
+  - uid: 143
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 301
+  - uid: 144
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 302
+  - uid: 145
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 309
+  - uid: 146
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 310
+  - uid: 147
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 313
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 314
+  - uid: 149
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 315
+  - uid: 150
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 316
+  - uid: 151
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 318
+  - uid: 152
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 319
+  - uid: 153
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 320
+  - uid: 154
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 321
+  - uid: 155
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 322
+  - uid: 156
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 325
+  - uid: 157
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 326
+  - uid: 158
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 327
+  - uid: 159
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 328
+  - uid: 160
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 329
+  - uid: 161
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 330
+  - uid: 162
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 331
+  - uid: 163
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 332
+  - uid: 164
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 334
+  - uid: 165
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 435
+  - uid: 166
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 436
+  - uid: 167
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 437
+  - uid: 168
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 438
+  - uid: 169
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 439
+  - uid: 170
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 440
+  - uid: 171
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 460
+  - uid: 172
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 464
+  - uid: 173
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 465
+  - uid: 174
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 466
+  - uid: 175
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 467
+  - uid: 176
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 468
+  - uid: 177
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 469
+  - uid: 178
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 470
+  - uid: 179
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 471
+  - uid: 180
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 472
+  - uid: 181
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 473
+  - uid: 182
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 474
+  - uid: 183
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 475
+  - uid: 184
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 476
+  - uid: 185
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 477
+  - uid: 186
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 478
+  - uid: 187
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 479
+  - uid: 188
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 480
+  - uid: 189
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 481
+  - uid: 190
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 482
+  - uid: 191
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 483
+  - uid: 192
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 484
+  - uid: 193
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 485
+  - uid: 194
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 486
+  - uid: 195
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 487
+  - uid: 196
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 488
+  - uid: 197
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 489
+  - uid: 198
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 490
+  - uid: 199
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 491
+  - uid: 200
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 492
+  - uid: 201
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 493
+  - uid: 202
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 494
+  - uid: 203
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 495
+  - uid: 204
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 113
+  - uid: 205
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 219
+  - uid: 206
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 254
+  - uid: 207
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 255
+  - uid: 208
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 256
+  - uid: 209
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 257
+  - uid: 210
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 258
+  - uid: 211
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 260
+  - uid: 212
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 264
+  - uid: 213
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 265
+  - uid: 214
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 266
+  - uid: 215
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 267
+  - uid: 216
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 345
+  - uid: 217
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 348
+  - uid: 218
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 403
+  - uid: 219
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 404
+  - uid: 220
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 429
+  - uid: 221
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 430
+  - uid: 222
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 431
+  - uid: 223
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 432
+  - uid: 224
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 433
+  - uid: 225
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 434
+  - uid: 226
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 498
+  - uid: 227
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 499
+  - uid: 228
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 500
+  - uid: 229
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 501
+  - uid: 230
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 65
+  - uid: 231
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 162
+  - uid: 232
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 199
+  - uid: 233
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 269
+  - uid: 234
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 270
+  - uid: 235
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 271
+  - uid: 236
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 272
+  - uid: 237
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 273
+  - uid: 238
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 278
+  - uid: 239
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 441
+  - uid: 240
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 442
+  - uid: 241
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 443
+  - uid: 242
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 444
+  - uid: 243
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 445
+  - uid: 244
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 446
+  - uid: 245
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 447
+  - uid: 246
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 448
+  - uid: 247
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 449
+  - uid: 248
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 450
+  - uid: 249
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 451
+  - uid: 250
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 503
+  - uid: 251
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 55
+  - uid: 252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 268
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1470,267 +1588,268 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 18
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,6.5
-      parent: 1
-  - uid: 46
+  - uid: 254
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 87
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 91
+  - uid: 256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 101
+  - uid: 257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 102
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 148
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 154
+  - uid: 259
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 156
+  - uid: 260
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 157
+  - uid: 261
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 161
+  - uid: 262
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 173
+  - uid: 263
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 175
+  - uid: 264
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 176
+  - uid: 265
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 184
+  - uid: 266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 185
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 222
+  - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 317
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 374
+  - uid: 270
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 375
+  - uid: 271
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 376
+  - uid: 272
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 378
+  - uid: 273
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 380
+  - uid: 274
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 381
+  - uid: 275
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 382
+  - uid: 276
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 383
+  - uid: 277
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 384
+  - uid: 278
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 385
+  - uid: 279
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 400
+  - uid: 280
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 407
+  - uid: 281
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 408
+  - uid: 282
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 409
+  - uid: 283
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 410
+  - uid: 284
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 411
+  - uid: 285
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 412
+  - uid: 286
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 413
+  - uid: 287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 414
+  - uid: 288
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 462
+  - uid: 289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 463
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
 - proto: CMSemioticExhaust
   entities:
-  - uid: 406
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-  - uid: 452
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 453
+  - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 454
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 455
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 456
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 457
+  - uid: 299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 458
+  - uid: 300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,11.5
       parent: 1
-  - uid: 461
+  - uid: 301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1738,29 +1857,29 @@ entities:
       parent: 1
 - proto: CMSemioticSilicon_storage
   entities:
-  - uid: 415
+  - uid: 302
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 416
+  - uid: 303
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 417
+  - uid: 304
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 418
+  - uid: 305
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 227
+  - uid: 306
     components:
     - type: Transform
       pos: -0.5,5.5
@@ -1771,7 +1890,7 @@ entities:
       startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 15
+  - uid: 307
     components:
     - type: Transform
       pos: 1.5,5.5
@@ -1782,7 +1901,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 246
+  - uid: 308
     components:
     - type: Transform
       pos: 0.5,5.5
@@ -1793,123 +1912,123 @@ entities:
       startingCharge: 0
 - proto: DarkCatwalkMono
   entities:
-  - uid: 389
+  - uid: 309
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 390
+  - uid: 310
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
 - proto: GeneratorRTG
   entities:
-  - uid: 134
+  - uid: 311
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 277
+  - uid: 312
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 72
+  - uid: 313
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 139
+  - uid: 314
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 141
+  - uid: 315
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 142
+  - uid: 316
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 496
+  - uid: 317
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 497
+  - uid: 318
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 114
+  - uid: 319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 125
+  - uid: 320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 127
+  - uid: 321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 180
+  - uid: 322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,2.5
       parent: 1
-  - uid: 181
+  - uid: 323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 275
+  - uid: 324
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 283
+  - uid: 325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 304
+  - uid: 326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 305
+  - uid: 327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 337
+  - uid: 328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 355
+  - uid: 329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1917,116 +2036,116 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 13
+  - uid: 330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 34
+  - uid: 331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 35
+  - uid: 332
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 79
+  - uid: 333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 1
-  - uid: 81
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 100
+  - uid: 335
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 117
+  - uid: 336
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 129
+  - uid: 337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 130
+  - uid: 338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 150
+  - uid: 339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 155
+  - uid: 340
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-  - uid: 168
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 170
+  - uid: 342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 220
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 221
+  - uid: 344
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 224
+  - uid: 345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 228
+  - uid: 346
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 276
+  - uid: 347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 286
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 459
+  - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2034,7 +2153,7 @@ entities:
       parent: 1
 - proto: GunneryServerMedium
   entities:
-  - uid: 99
+  - uid: 350
     components:
     - type: Transform
       pos: -0.5,3.5
@@ -2045,32 +2164,32 @@ entities:
       powerLoad: 10
 - proto: GyroscopeSecurity
   entities:
-  - uid: 96
+  - uid: 351
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
 - proto: HighSecDoor
   entities:
-  - uid: 32
+  - uid: 352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-  - uid: 61
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,5.5
       parent: 1
-  - uid: 92
+  - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 336
+  - uid: 355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2078,32 +2197,32 @@ entities:
       parent: 1
 - proto: MachineFTLDrive25S
   entities:
-  - uid: 250
+  - uid: 356
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 97
+  - uid: 357
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 104
+  - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 1
-  - uid: 112
+  - uid: 359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 167
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2111,44 +2230,44 @@ entities:
       parent: 1
 - proto: PlayerStationAiRedacted
   entities:
-  - uid: 223
+  - uid: 361
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 103
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 405
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 427
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 428
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 526
+  - uid: 366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 527
+  - uid: 367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2156,79 +2275,79 @@ entities:
       parent: 1
 - proto: PoweredStrobeRedEnabled
   entities:
-  - uid: 352
+  - uid: 368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 354
+  - uid: 369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,15.5
       parent: 1
-  - uid: 356
+  - uid: 370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 361
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 419
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,6.5
-      parent: 1
-  - uid: 420
+  - uid: 371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 421
+  - uid: 372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,12.5
       parent: 1
-  - uid: 422
+  - uid: 373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 423
+  - uid: 374
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 424
+  - uid: 375
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 425
+  - uid: 376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 426
+  - uid: 377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 350
+  - uid: 380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2236,28 +2355,28 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 391
+  - uid: 381
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 392
+  - uid: 382
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 393
+  - uid: 383
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 396
+  - uid: 384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 397
+  - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2265,13 +2384,13 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 394
+  - uid: 386
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 395
+  - uid: 387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2279,173 +2398,170 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 521
+  - uid: 388
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        67:
+        115:
         - - Pressed
           - Toggle
-  - uid: 522
+  - uid: 389
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        70:
+        116:
         - - Pressed
           - Toggle
 - proto: SMESAdvanced
   entities:
-  - uid: 89
+  - uid: 390
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 123
+  - uid: 391
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
 - proto: SpawnMobWeaponTurretLaserSilicon
   entities:
-  - uid: 68
+  - uid: 392
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 502
+  - uid: 393
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
 - proto: SpawnRedactedBorg
   entities:
-  - uid: 144
+  - uid: 394
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
 - proto: StairStageDark
   entities:
-  - uid: 398
+  - uid: 395
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 399
+  - uid: 396
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 90
+  - uid: 397
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 119
+  - uid: 398
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
 - proto: SurveillanceCameraConstructed
   entities:
-  - uid: 338
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 388
+  - uid: 399
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 504
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 505
+  - uid: 401
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 1
-  - uid: 506
-    components:
-    - type: Transform
-      pos: 4.5,6.5
-      parent: 1
-  - uid: 507
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 508
+  - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,14.5
       parent: 1
-  - uid: 509
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 510
+  - uid: 404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 1
-  - uid: 511
+  - uid: 405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 512
+  - uid: 406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 513
+  - uid: 407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-  - uid: 514
+  - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 515
+  - uid: 409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
+- proto: SurveillanceCameraGeneral
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
 - proto: ThrusterLarge
   entities:
-  - uid: 76
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 251
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2453,69 +2569,69 @@ entities:
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 16
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 39
+  - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 64
+  - uid: 416
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 98
+  - uid: 417
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 105
+  - uid: 418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 120
+  - uid: 419
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 132
+  - uid: 420
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 143
+  - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 169
+  - uid: 422
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 261
+  - uid: 423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 274
+  - uid: 424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 303
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2523,491 +2639,499 @@ entities:
       parent: 1
 - proto: WallNanolaminate
   entities:
-  - uid: 324
+  - uid: 426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,13.5
       parent: 1
-  - uid: 359
+  - uid: 429
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,4.5
+      pos: -3.5,6.5
       parent: 1
-  - uid: 387
+  - uid: 430
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,4.5
+      pos: 4.5,6.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 431
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 1
-  - uid: 3
+  - uid: 432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,15.5
       parent: 1
-  - uid: 4
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 5
+  - uid: 434
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 6
+  - uid: 435
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 7
+  - uid: 436
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 8
+  - uid: 437
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 9
+  - uid: 438
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 10
+  - uid: 439
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 11
+  - uid: 440
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 12
+  - uid: 441
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 14
+  - uid: 442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 20
+  - uid: 443
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 22
+  - uid: 444
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 24
+  - uid: 445
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 25
+  - uid: 446
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 26
+  - uid: 447
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 27
+  - uid: 448
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 29
+  - uid: 449
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 30
+  - uid: 450
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 31
+  - uid: 451
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 33
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 36
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 37
+  - uid: 454
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 38
+  - uid: 455
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,7.5
       parent: 1
-  - uid: 42
+  - uid: 456
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 43
+  - uid: 457
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 44
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 45
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 53
+  - uid: 460
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 56
+  - uid: 461
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 57
+  - uid: 462
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 60
+  - uid: 463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 62
+  - uid: 464
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 63
+  - uid: 465
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 66
+  - uid: 466
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,6.5
       parent: 1
-  - uid: 75
+  - uid: 467
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 78
+  - uid: 468
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 82
+  - uid: 469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 84
+  - uid: 470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,7.5
       parent: 1
-  - uid: 85
+  - uid: 471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 86
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 88
+  - uid: 473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 93
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 1
-  - uid: 94
+  - uid: 475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 95
+  - uid: 476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 107
+  - uid: 477
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 109
+  - uid: 478
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 115
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 118
+  - uid: 481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 126
+  - uid: 482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 133
+  - uid: 483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
-  - uid: 136
+  - uid: 484
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 140
+  - uid: 485
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 149
+  - uid: 486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 151
+  - uid: 487
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 164
+  - uid: 488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 165
+  - uid: 489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-  - uid: 179
+  - uid: 490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 183
+  - uid: 491
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 210
+  - uid: 492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 211
+  - uid: 493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 213
+  - uid: 494
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 217
+  - uid: 495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 218
+  - uid: 496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,3.5
       parent: 1
-  - uid: 225
+  - uid: 497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 226
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 259
+  - uid: 499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 263
+  - uid: 500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 287
+  - uid: 501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 295
+  - uid: 502
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 296
+  - uid: 503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,16.5
       parent: 1
-  - uid: 307
+  - uid: 504
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 308
+  - uid: 505
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 333
+  - uid: 506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 340
+  - uid: 507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 341
+  - uid: 508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 347
+  - uid: 509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 349
+  - uid: 510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 353
+  - uid: 511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 357
+  - uid: 512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-1.5
       parent: 1
-  - uid: 379
+  - uid: 513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 386
+  - uid: 514
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3015,59 +3139,59 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 17
+  - uid: 515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 58
+  - uid: 516
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 71
+  - uid: 517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 128
+  - uid: 518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 131
+  - uid: 519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 138
+  - uid: 520
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 163
+  - uid: 521
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 172
+  - uid: 522
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 262
+  - uid: 523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,0.5
       parent: 1
-  - uid: 306
+  - uid: 524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3075,13 +3199,13 @@ entities:
       parent: 1
 - proto: WeaponLaserTurretFlayer
   entities:
-  - uid: 285
+  - uid: 525
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,4.5
       parent: 1
-  - uid: 339
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3089,7 +3213,7 @@ entities:
       parent: 1
 - proto: WeaponTurretTartarus
   entities:
-  - uid: 153
+  - uid: 527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3097,16 +3221,16 @@ entities:
       parent: 1
 - proto: WeaponTurretTorpedoEntropy
   entities:
-  - uid: 137
+  - uid: 528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,6.5
+      pos: 4.5,7.5
       parent: 1
-  - uid: 377
+  - uid: 529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,6.5
+      pos: -3.5,7.5
       parent: 1
 ...


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Мелкий хотфикс вирма, который мешал Азакиму проходить внутрь

## Почему / Баланс
Торпедные установки пришлось пододвинуть вперёд и закрыть стеночкой, т.к. после стрельбы они слегка поворачивались и сужали окно прохода, из-за чего Азакимы застревают в этих самых проходах.

## Медиа
<img width="1688" height="1828" alt="изображение" src="https://github.com/user-attachments/assets/765fe2da-d8bf-4dd8-8f41-1385423a9925" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->
