### PR TITLE
Remove RazorN

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -11,7 +11,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: UnknownShuttleZenithE
-    - id: UnknownShuttleRazorN
+    # - id: UnknownShuttleRazorN Exodus-Remove-NukeCar
     - id: UnknownShuttleWyvern
     - id: UnknownShuttleZenith
     - id: UnknownShuttleWyrm
@@ -97,25 +97,7 @@
       department: Combatant
       minDepartmentPlayers: 3
 
-- type: entity
-  parent: BaseRandomShuttleRule
-  id: UnknownShuttleRazorN
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
-    startAudio:
-      path: /Audio/Misc/notice1.ogg
-    weight: 2 # rare but not too rare since it's in the T2 spawner
-    maxOccurrences: 2
-  - type: GameRule
-    minPlayers: 15
-  - type: LoadMapRule
-    gridPath: /Maps/_Mono/ShuttleEvent/razorn.yml
-  - type: GameRuleRequirements # Exodus
-    requirements:
-    - !type:JobGameRuleRequirement
-      department: Combatant
-      minDepartmentPlayers: 7
+# Exodus-Remove-NukeCar
 
 - type: entity
   parent: BaseRandomShuttleRule


### PR DESCRIPTION
## Описание PR
Удаление вариации шаттла АСЗ с аналогом ядерного заряда.

## Почему / Баланс
<img width="897" height="635" alt="изображение" src="https://github.com/user-attachments/assets/685f83fa-b56d-465e-93e1-64900ad41cc2" />

Данная вариация шаттла автоматической системы защиты вызывает ОЧЕНЬ много вопросов. Как со стороны простой логики, так и со стороны ценности в геймплее. Она представляет из себя консервную банку 13 на 13 тайлов, которая, по сути своей, имеет как раз только эту бомбу... И это ужас. Это буквально руин игры и себе и другим, если ты играешь за оператора или ядро на шаттле - ты просто идешь и взрываешься, убивая себя (практически без шансов) и других, что в итоге превращает этот шахидмобиль в мощный инструмент грифа. Я не думаю, что стоит такое оставлять в билде, потому что что как по правилам игры, что по законам АСЗ, этим можно пользоваться просто в единичных случаях не нарушая что либо.

 Также хочу добавить о том, что по сути, применение этого шаттла дает в целом слишком большое преимущество, и противостоять этому очень сложно - снести шаттл может быть мало, ведь сам заряд не имеет компонента разрушения, из-за чего в итоге выходит так, что обезвредить его можно только если успеть уничтожить вылетевший из бсса шаттл так, чтобы снести пол под зарядом, что не всегда может быть возможно и чистый рандом, да и в целом стрелять по такой цели крайне сложно ввиду огромноц скорости и мбс с очень быстрой перезарядкой .

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- remove: Удалена вариация АСЗ Разор с оружием массового поражения.