### PR TITLE
Small try to stabilize economy

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -12,15 +12,15 @@
     shape: square
   - type: SpawnItemsOnUse
     items:
-    # Money - 30k
+    # Money - 10k # Exodus-Economic-Rebalance
     - id: SpaceCash10000
-      amount: 3
-    # Scrap chunks
-    - id: ScrapOre100
       amount: 1
-    # Material
+    # Scrap chunks
+    - id: ScrapOre50 # Exodus-Economic-Rebalance
+      amount: 1
+    # Material # Exodus-Economic-Rebalance
     - id: SheetPlastitanium10
-      amount: 2
+      amount: 1
     # Parts
     - id: SuperCapacitorStockPart
       prob: 0.8
@@ -71,16 +71,16 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    # Money - 80k
+    # Money - 30k # Exodus-Economic-Rebalance
     - id: SpaceCash25000
-      amount: 3
+      amount: 1
     - id: SpaceCash5000
-    # Scrap chunks
+    # Scrap chunks  # Exodus-Economic-Rebalance
     - id: ScrapOre100
-      amount: 3
-    # Material
+      amount: 1
+    # Material # Exodus-Economic-Rebalance
     - id: SheetPlastitanium10
-      amount: 4
+      amount: 2
     # Parts
     - id: SuperCapacitorStockPart
       amount: 3
@@ -88,14 +88,14 @@
       amount: 1
     - id: PicoManipulatorStockPart
       amount: 2
-    # rare t4 parts
+    # rare t4 parts # Exodus-Economic-Rebalance
     - id: QuadraticCapacitorStockPart
       amount: 2
-      prob: 0.8
+      prob: 0.4
     - id: FemtoManipulatorStockPart
-      prob: 0.8
+      prob: 0.4
     - id: BluespaceMatterBinStockPart
-      prob: 0.6
+      prob: 0.3
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
     - id: PowerCellMicroreactor
@@ -123,16 +123,16 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    # Money - 200k
+    # Money - 100k # Exodus-Economic-Rebalance
     - id: SpaceCash100000
-      amount: 2
-    # Scrap chunks
+      amount: 1
+    # Scrap chunks  # Exodus-Economic-Rebalance
     - id: ScrapOre100
-      amount: 6
-    # Material
+      amount: 2
+    # Material  # Exodus-Economic-Rebalance
     - id: SheetPlastitanium10
-      amount: 8
-    # Parts
+      amount: 4
+    # Parts 
     - id: SuperCapacitorStockPart
       amount: 6
     - id: SuperMatterBinStockPart
@@ -159,10 +159,10 @@
       maxAmount: 2
     - id: WeaponTurretPinholeFlatpack
     # no flatpacks or boards, just gamble scrap
-    # Research disk, expected value 200k/drone
+    # Research disk, expected value 200k/drone  # Exodus-Economic-Rebalance
     - id: RogueSiliconResearchDisk50000
-      amount: 3
-      maxAmount: 5
+      amount: 1
+      maxAmount: 3
     # Tech disk
     - id: SpawnLootTechDisksT3Mech
       prob: 0.6

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -209,7 +209,7 @@
   unit: materials-unit-sheet
   icon: { sprite: /Textures/_Mono/Objects/Materials/fissiles.rsi, state: uranium }
   color: "#8a8568"
-  price: 250 # 25000/sheet
+  price: 100 # 10000/sheet # Exodus-Price-Rebalance
   properties: # FH edit
     electrical: 4
     thermal: 3

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -50,7 +50,7 @@
     rootTask:
       task: RammerShuttleCompound
   - type: StaticPrice
-    price: 20000
+    price: 10000 # Exodus-Price-Rebalance
   - type: ApcPowerReceiver
     powerLoad: 1000 # suspiciously low power-using AI
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/12.7x99mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/12.7x99mm.yml
@@ -37,6 +37,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 - type: entity
   parent: BaseAmmoBox127x99mm

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/14.5x114mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/14.5x114mm.yml
@@ -31,6 +31,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 # Boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/4.6x30mm.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_magnum.yml
@@ -32,6 +32,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.56x45mm.yml
@@ -36,6 +36,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.7x28mm.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm.yml
@@ -31,6 +31,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 # Boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
@@ -34,6 +34,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 # Boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x39mm.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x51mm.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/7.62x54mmR.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/8x65mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/8x65mm.yml
@@ -31,6 +31,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 # Boxes
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/9x19mm.yml
@@ -35,6 +35,8 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: StaticPrice # Exodus-Price-Rebalance
+    price: 30
 
 #small ammo boxes
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -77,7 +77,7 @@
   - type: Flatpack
     entity: WeaponCapacitorRecharger
   - type: StaticPrice
-    price: 15
+    price: 55 # Exodus-Price-Rebalance
 
 - type: entity
   parent: BaseNFFlatpack


### PR DESCRIPTION
## Описание PR
Уменьшение цены некоторых предметов и лута с дронов. Удаление возможности заработать на перепродаже коробок с патронами.

## Почему / Баланс
Сейчас 3 столпами - майнеры, уран и дроны. В этом же ПРе я хотел бы затронуть второй и третий способы, а именно чуть снизить их эффективность. Опять же, сравнивая с другими способами заработка, способо полететь за дронами и наварить с них уран кажется чуть ли не самым эффективным впринципе, и моя цель все же если и оставить его таковым, но сильно его порезав, позволяя делать миллионы, но не десятки миллионов. В остальном я сделал именно что уменьшение количества дропа с дронов, чем их в целом резал (условно, срезал 60% награды с т1 ящика). Уран же я затронул в том плане, что снизил его стоимость на те же 60%, оставив его все равно относительно дорогим. Возможно, где-то и стоит покрутить циферки в большую/меньшую сторону, но я оставил пока на своё усмотрение.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: JunJun
- tweak: Снижена цена делящегося урана на 60%.
- tweak: Снижена цена ядра дрона на 50%.
- tweak: Снижено количество выпадаемых материалов, денег и немного понижен шанс выпадения деталей с лутовых коробок дронов
- fix: Исправлена возможность перепродажи пачки патронов в плюс себе.
