### PR TITLE
Radio update

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Shuttles.Components;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -226,8 +227,11 @@ public sealed class RadioSystem : EntitySystem
             if (!HasComp<GhostComponent>(receiver) && GetFrequency(receiver, channel) != frequency) // Nuclear-14
                 continue; // Nuclear-14
 
-            // if (!channel.LongRange && transform.MapID != sourceMapId && !radio.GlobalReceive)
-            //     continue;
+            if (!channel.LongRange
+                && !HasComp<FTLMapComponent>(transform.MapUid)
+                && transform.MapID != sourceMapId
+                && !radio.GlobalReceive) // Exodus
+                continue;
 
             // Check if within range for range-limited channels
             if (channel.MaxRange.HasValue && channel.MaxRange.Value > 0)

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -28,7 +28,7 @@ public abstract class SharedChatSystem : EntitySystem
     public const char DefaultChannelKey = 'р'; // RU-Localization
 
     [ValidatePrototypeId<RadioChannelPrototype>]
-    public const string CommonChannel = "Traffic"; // Exodus
+    public const string CommonChannel = "Common"; // Exodus
 
     public static string DefaultChannelPrefix = $"{RadioChannelPrefix}{DefaultChannelKey}";
 

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,7 +4,6 @@
   keycode: ";" # Ru-Localization
   frequency: 1459
   color: "#2cdb2c"
-  maxRange: 7500 # Exodus
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
1. Общий канал полностью восстановлен
2. Исправлен префикс отправки в общий канал на `;` заместо кривого `:;`
3. Убрана коммуникация между картами, но оставлена связь в гипер-пространстве

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Общий канал был полностью восстановлен
- tweak: Учёные сообщают об изменениях активности Монолита: прямой радио-эфир между сектором и экспедициями затруднён
- fix: Общий канал теперь работает через `;` как и должен был, заместо `:;`
