### PR TITLE
Asakim faction fix

### DIFF
--- a/Resources/Locale/ru-RU/_Exodus/prototypes/entities/mobs/turrets.ftl
+++ b/Resources/Locale/ru-RU/_Exodus/prototypes/entities/mobs/turrets.ftl
@@ -1,0 +1,4 @@
+ent-WeaponTurretLaserAsakim = лазерная турель
+    .desc = Лазерная турель до-раскольного образца
+ent-WeaponTurretHeavyAsakim = тяжёлая турель
+    .desc = Тяжёлая турель до-раскольного образца

--- a/Resources/Locale/ru-RU/_Exodus/prototypes/entities/spawners/mobspawners.ftl
+++ b/Resources/Locale/ru-RU/_Exodus/prototypes/entities/spawners/mobspawners.ftl
@@ -1,0 +1,2 @@
+ent-SpawnMobWeaponTurretLaserAsakim = спавнер лазерной турели азакимов
+ent-SpawnMobWeaponTurretHeavyAsakim = спавнер тяжёлой турели азакимов

--- a/Resources/Maps/_Exodus/ShuttleEvent/concord_x.yml
+++ b/Resources/Maps/_Exodus/ShuttleEvent/concord_x.yml
@@ -7755,7 +7755,7 @@ entities:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-- proto: SpawnMobWeaponTurretLaserSyndicateNF
+- proto: SpawnMobSpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 1098
     components:

--- a/Resources/Maps/_Exodus/ShuttleEvent/wyrm.yml
+++ b/Resources/Maps/_Exodus/ShuttleEvent/wyrm.yml
@@ -2430,7 +2430,7 @@ entities:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-- proto: SpawnMobWeaponTurretLaserSilicon
+- proto: SpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 392
     components:

--- a/Resources/Maps/_Exodus/ShuttleEvent/zenith.yml
+++ b/Resources/Maps/_Exodus/ShuttleEvent/zenith.yml
@@ -2793,7 +2793,7 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-- proto: SpawnMobWeaponTurretLaserSyndicateNF
+- proto: SpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 426
     components:

--- a/Resources/Maps/_Exodus/ShuttleEvent/zenith_e.yml
+++ b/Resources/Maps/_Exodus/ShuttleEvent/zenith_e.yml
@@ -2797,7 +2797,7 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-- proto: SpawnMobWeaponTurretLaserSyndicateNF
+- proto: SpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 426
     components:

--- a/Resources/Maps/_Mono/Bluespace/prefracture.yml
+++ b/Resources/Maps/_Mono/Bluespace/prefracture.yml
@@ -2549,7 +2549,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 864
-- proto: SpawnMobWeaponTurretLaserSilicon
+- proto: SpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 82
     components:
@@ -3977,7 +3977,7 @@ entities:
       parent: 864
     missingComponents:
     - Anchorable
-- proto: WeaponTurretHeavySilicon
+- proto: WeaponTurretHeavyAsakim # Exodus-asakim-fix
   entities:
   - uid: 1207
     components:

--- a/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
@@ -37981,7 +37981,7 @@ entities:
     - type: Transform
       pos: 2.4304535,62.269913
       parent: 1
-- proto: SpawnMobWeaponTurretLaserSyndicateNF
+- proto: SpawnMobWeaponTurretLaserAsakim # Exodus-asakim-fix
   entities:
   - uid: 6026
     components:

--- a/Resources/Prototypes/_Exodus/Entities/Objects/turrets.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Objects/turrets.yml
@@ -1,0 +1,49 @@
+- type: entity
+  id: WeaponTurretLaserAsakim
+  name: laser turret
+  suffix: Asakim
+  parent:
+  - WeaponTurretLaserSyndicateNF
+  components:
+  - type: NpcFactionMember
+    factions:
+    - AsakimDefenceForces
+
+- type: entity
+  parent: BallisticTurretHeavyBase
+  id: WeaponTurretHeavyAsakim
+  suffix: Asakim
+  components:
+  - type: NpcFactionMember
+    factions:
+    - AsakimDefenceForces
+
+# spawners
+- type: entity
+  id: SpawnMobWeaponTurretLaserAsakim
+  parent: MarkerBase
+  name: asakim laser turret spawner
+  suffix: Asakim
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _NF/Objects/Weapons/Guns/Turrets/laser.rsi
+      state: base
+  - type: ConditionalSpawner
+    prototypes:
+    - WeaponTurretLaserAsakim
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnMobWeaponTurretHeavyAsakim
+  suffix: Asakim
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: _Mono/Objects/Weapons/Turrets/heavy_turret.rsi
+      state: base
+  - type: ConditionalSpawner
+    prototypes:
+    - WeaponTurretHeavyAsakim

--- a/Resources/Prototypes/_Exodus/Entities/Objects/turrets.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Objects/turrets.yml
@@ -43,7 +43,7 @@
     layers:
     - state: red
     - sprite: _Mono/Objects/Weapons/Turrets/heavy_turret.rsi
-      state: base
+      state: syndie_lethal
   - type: ConditionalSpawner
     prototypes:
     - WeaponTurretHeavyAsakim

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -140,7 +140,7 @@
   components:
   - type: NpcFactionMember
     factions:
-    - Syndicate
+    # - Syndicate # Exodus-asakim-fix
     - SiliconsExpeditionNF
   - type: Access
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -141,7 +141,7 @@
   - type: NpcFactionMember
     factions:
     # - Syndicate # Exodus-asakim-fix
-    - SiliconsExpeditionNF
+    - AsakimDefenceForces # Exodus-asakim-fix
   - type: Access
     tags:
     - NuclearOperative

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
@@ -115,7 +115,7 @@
   - type: Wagging
   - type: NpcFactionMember
     factions:
-    - SiliconsExpeditionNF # Exodus-asakim-fix # Making new AI factions is annoying with all the hostilities I have to add, whatever. 
+    - AsakimDefenceForces # Exodus-asakim-fix # Making new AI factions is annoying with all the hostilities I have to add, whatever. 
   - type: Inventory
     speciesId: asakim
     # WWDP-Edit-Start

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
@@ -115,7 +115,7 @@
   - type: Wagging
   - type: NpcFactionMember
     factions:
-    - Syndicate # Making new AI factions is annoying with all the hostilities I have to add, whatever.
+    - SiliconsExpeditionNF # Exodus-asakim-fix # Making new AI factions is annoying with all the hostilities I have to add, whatever. 
   - type: Inventory
     speciesId: asakim
     # WWDP-Edit-Start

--- a/Resources/Prototypes/_NF/ai_factions.yml
+++ b/Resources/Prototypes/_NF/ai_factions.yml
@@ -80,6 +80,8 @@
 
 - type: npcFaction
   id: SiliconsExpeditionNF
+  friendly: # Exodus-asakim-fix
+  -  AsakimDefenceForces # Exodus-asakim-fix
   defaultHostile: true
 
 - type: npcFaction
@@ -103,3 +105,12 @@
   defaultHostile: true
 
 # Mono edit end.
+
+# Exodus-asakim-fix-start 
+- type: npcFaction
+  id: AsakimDefenceForces
+  friendly:
+  - SiliconsExpeditionNF
+  defaultHostile: true
+
+# Exodus-asakim-end


### PR DESCRIPTION
[Исправление согласно запросу
](https://discord.com/channels/1097181193939730453/1496169786999177216)
Поменял фракцию азакимам и АДС с сидиката на AsakimDefenceForces, которая дружелюбна к SiliconsExpeditionNF.
Теперь Азакимы не смогут забирать лут с точек синди, а турели на шаттлах АДС не будут по ним стрелять. 
Ну вроде бы +- даже лорно, ии типа старый, азакимы тоже, ыыы. 

- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

:cl: Lancevrot
- tweak: Теперь турели на шаттлах АДС не будут стрелять по азакимам.
- fix: Азакимы больше не смогут гулять по точкам с НПС синдиката как у себя дома.