### PR TITLE
Add Camera and Reinforced Tile into RCD

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -377,6 +377,7 @@
     - MVCable
     - HVCable
     - CableTerminal
+    - SurveillanceCameraConstructed # Exodus RCD additions
     - Deconstruct
     # mono start
     - WallReinforced
@@ -385,6 +386,7 @@
     - SMES
     - Substation
     - Plating # Not mono, taken in for prettiness
+    - FloorHullReinforced # Exodus RCD additions
     - PlatingCornerNE
     - PlatingCornerNW
     - PlatingCornerSE

--- a/Resources/Prototypes/_Exodus/RCD/rcd.yml
+++ b/Resources/Prototypes/_Exodus/RCD/rcd.yml
@@ -14,6 +14,7 @@
 
 - type: rcd
   id: SurveillanceCameraConstructed
+  name: surveillance-camera-constructed
   category: Electrical
   sprite: { sprite: Structures/Wallmounts/camera.rsi, state: camera_off }
   mode: ConstructObject

--- a/Resources/Prototypes/_Exodus/RCD/rcd.yml
+++ b/Resources/Prototypes/_Exodus/RCD/rcd.yml
@@ -1,0 +1,26 @@
+- type: rcd
+  id: FloorHullReinforced
+  name: tiles-hull-reinforced
+  category: PlatingTiles
+  sprite: /Textures/Tiles/hull_reinforced.png
+  mode: ConstructTile
+  prototype: FloorHullReinforced
+  cost: 75
+  delay: 2
+  collisionMask: InteractImpassable
+  rules:
+  - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct2
+
+- type: rcd
+  id: SurveillanceCameraConstructed
+  category: Electrical
+  sprite: { sprite: Structures/Wallmounts/camera.rsi, state: camera_off }
+  mode: ConstructObject
+  prototype: SurveillanceCameraConstructed
+  cost: 15
+  delay: 2
+  collisionMask: TabletopMachineMask
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rotation: User
+  fx: EffectRCDConstruct2


### PR DESCRIPTION
## Описание PR
Добавил для РСУ:
1. Наружная укрепленная обшивка.
Стоимость 75.
2. Камера
Стоимость 15.

## Почему / Баланс
Камеры дешевы в производстве, а наружную укрепленную обшивку стоило добавить вместе со взрывами пушек ранее. Теперь игроки могут нормально строить корабли без потери пушек в важных местах.

## Технические детали


## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения

**Список изменений**
:cl:
- add: Добавлена наружная укрепленная обшивка и камеры наблюдения в РСУ.
