### PR TITLE
Feat: raise a bit more hours for DirectorOfCare

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Medical/doc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Medical/doc.yml
@@ -16,7 +16,7 @@
   #     time: 234000 # mono 65 hours
     - !type:RoleTimeRequirement
       role: MdMedic
-      time: 36000 # 10 hours
+      time: 54000 # 15 hours # Exodus paramed-lead-hours
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hours
   # Exodus-Rework-Time-Roles-End


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Количество часов для Заведующий СНМП поднято до 15 часов на медиках (с 10 часов).

## Почему / Баланс
По просьбам трудящихся
https://discord.com/channels/1097181193939730453/1518640648964538480/1518640648964538480

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- tweak: Повышено требуемое количество наигранных в медотделе часов, для открытия роли заведующего (С 10 до 15).