### PR TITLE
AI Control borgs to ships

### DIFF
--- a/Resources/Maps/_Exodus/Shuttles/Capitals/flyssa.yml
+++ b/Resources/Maps/_Exodus/Shuttles/Capitals/flyssa.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 04/16/2026 13:15:13
-  entityCount: 3238
+  entityCount: 3239
 maps: []
 grids:
 - 1
@@ -15260,6 +15260,13 @@ entities:
     components:
     - type: Transform
       pos: 2.5,29.5
+      parent: 1
+- proto: SpawnAiRemoteBorgTSF
+  entities:
+  - uid: 3239
+    components:
+    - type: Transform
+      pos: 1.5,29.5
       parent: 1
 - proto: SpawnMechRipley
   entities:

--- a/Resources/Maps/_Exodus/Shuttles/Capitals/saturn.yml
+++ b/Resources/Maps/_Exodus/Shuttles/Capitals/saturn.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 04/16/2026 13:15:21
-  entityCount: 4000
+  entityCount: 4001
 maps: []
 grids:
 - 1
@@ -19727,6 +19727,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,21.5
+      parent: 1
+- proto: SpawnAiRemoteBorgPDV
+  entities:
+  - uid: 4001
+    components:
+    - type: Transform
+      pos: 0.5,37.5
       parent: 1
 - proto: SpawnMechRipley2
   entities:

--- a/Resources/Maps/_Mono/Shuttles/Expedition/arkansaw.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/arkansaw.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 08/20/2025 20:52:36
-  entityCount: 3330
+  entityCount: 3336
 maps: []
 grids:
 - 1
@@ -18474,6 +18474,15 @@ entities:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
+# Exodus-begin remote borg spawner
+- proto: SpawnAiRemoteBorgBattery
+  entities:
+  - uid: 3336
+    components:
+    - type: Transform
+      pos: -0.5,24.5
+      parent: 1
+# Exodus-end
 - proto: SpawnPointLatejoin
   entities:
   - uid: 2118


### PR DESCRIPTION
## Описание PR
Добавил на Аркансоу, Сатурн и Флиссу соответствующие спавнеры боргов для вселения ИИ в них.

## Почему / Баланс
Повышаем играбельность синтетиков. Постепенно приводим в играбельное состояние.

## Технические детали
У Аркансоу было изначально entityCount 3330, но проглядев файл, оказывается там были энтити 3331 и т.д. Привел в норму.

## Медиа
<img width="448" height="520" alt="изображение" src="https://github.com/user-attachments/assets/9bb4f7d7-a4d0-4c22-ac80-e00bc032021f" />
<img width="630" height="477" alt="изображение" src="https://github.com/user-attachments/assets/23fe4132-6e1b-424f-95d4-06967313cab4" />
<img width="336" height="462" alt="изображение" src="https://github.com/user-attachments/assets/c863e620-d123-45c7-b218-1b4813e29192" />

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения


**Список изменений**
:cl:
- add: Аркансоу, Сатурн и Флисса получили соответствующие шасси боргов для вселения ИИ в них.