### PR TITLE
Dicebag filling fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/dice_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice_bag.yml
@@ -19,8 +19,9 @@
   - type: Item
     size: Small
   - type: Storage
+    maxItemSize: Tiny # Exodus: fit default dice fill
     grid:
-    - 0,0,3,1
+    - 0,0,8,1 # Exodus: fit default dice fill
     whitelist:
       tags:
       - Dice


### PR DESCRIPTION
## Описание PR

Фикс бага, выявленного интеграционными тестами CI в небуле и других PR'ах.

DiceBag при спавне заполняется набором дайсов через StorageFill, но его хранилище было слишком маленьким для полного набора. Из-за этого система логировала ошибку о недостаточной вместимости, а интеграционные тесты падали.

Увеличена вместимость DiceBag, чтобы стартовый набор дайсов корректно помещался внутрь.

## Почему / Баланс


## Технические детали


## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.


## Критические изменения

**Список изменений**
:cl:
- fix: Пофикшена недостаточная вместимость мешочка для дайсов.