### PR TITLE
Economy Tweaks

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -16,12 +16,9 @@
     # Scrap chunks
     - id: ScrapOre100
       amount: 1
-    # Scrap chunks
-    - id: ScrapOre50 # Exodus-Economic-Rebalance
-      amount: 1
-    # Material # Exodus-Economic-Rebalance
+    # Material
     - id: SheetPlastitanium10
-      amount: 1
+      amount: 2
     # Parts
     - id: SuperCapacitorStockPart
       prob: 0.8
@@ -75,10 +72,10 @@
     # Money - 80k # removed
     # Scrap chunks
     - id: ScrapOre100
-      amount: 1
-    # Material # Exodus-Economic-Rebalance
+      amount: 3
+    # Material
     - id: SheetPlastitanium10
-      amount: 2
+      amount: 4
     # Parts
     - id: SuperCapacitorStockPart
       amount: 3
@@ -86,14 +83,14 @@
       amount: 1
     - id: PicoManipulatorStockPart
       amount: 2
-    # rare t4 parts # Exodus-Economic-Rebalance
+    # rare t4 parts
     - id: QuadraticCapacitorStockPart
       amount: 2
-      prob: 0.4
+      prob: 0.8
     - id: FemtoManipulatorStockPart
-      prob: 0.4
+      prob: 0.8
     - id: BluespaceMatterBinStockPart
-      prob: 0.3
+      prob: 0.6
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
     - id: PowerCellMicroreactor
@@ -124,10 +121,10 @@
     # Money - 200k # removed
     # Scrap chunks
     - id: ScrapOre100
-      amount: 2
-    # Material  # Exodus-Economic-Rebalance
+      amount: 6
+    # Material
     - id: SheetPlastitanium10
-      amount: 4
+      amount: 8
     # Parts
     - id: SuperCapacitorStockPart
       amount: 6
@@ -155,10 +152,10 @@
       maxAmount: 2
     - id: WeaponTurretPinholeFlatpack
     # no flatpacks or boards, just gamble scrap
-    # Research disk, expected value 200k/drone  # Exodus-Economic-Rebalance
+    # Research disk, expected value 200k/drone
     - id: RogueSiliconResearchDisk50000
-      amount: 1
-      maxAmount: 3
+      amount: 3
+      maxAmount: 5
     # Tech disk
     - id: SpawnLootTechDisksT3Mech
       prob: 0.6

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -208,7 +208,7 @@
     range: 500
   - type: FireControlRotate
   - type: Gun
-    fireRate: 2 # Exodus-Balance: 5>2
+    fireRate: 4 # Exodus-Balance: 5>4
     recoil: 2 # 2/25x
     projectileSpeed: 20
     minAngle: 0
@@ -252,8 +252,8 @@
   - type: ShipRepairable
     repairTime: 10
     repairCost: 20
-  - type: OreDropModifier # Exodus: half ore drop by ship gun
-    modifier: 0.5
+#  - type: OreDropModifier # Exodus: half ore drop by ship gun
+#    modifier: 0.5
 
 # RUBICON
 
@@ -616,7 +616,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 10 # Exodus-Balance: 20>10
+    fireRate: 15 # Exodus-Balance: 20>15
     recoil: 0
     minAngle: 0
     maxAngle: 0
@@ -650,8 +650,8 @@
   - type: ShipRepairable
     repairTime: 25
     repairCost: 100
-  - type: OreDropModifier # Exodus: half ore drop by ship gun
-    modifier: 0.5
+#  - type: OreDropModifier # Exodus: half ore drop by ship gun
+#    modifier: 0.5
 
 # PRE- FRACTURE
 


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
revert drone_loot.yml to actual Monolith state

Small up's ore nerfs

## Почему / Баланс
Исходя из тестов и фидбека, нынешнее состояние гринда переросло из казуального в неоправданно сложный и тяжелый. Подобные ребалансы, которые мы провели со своей стороны не принесли необходимого результата, а лишь дали душку ради душки. 

Проблема со стабильностью экономики остается, но чтобы решить её необходимо подходить к ней комплексно, подобные способы решения A.K.A +1 -1 не дали необходимого выхлопа.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения


**Список изменений**

:cl:
- tweak: Откатаны изменения дропа с лута дронов
- fix: Немного усилены майнинговые пушки
