### PR TITLE
Cyrex, Hydra, Bofors screwing

### DIFF
--- a/Resources/Prototypes/_Exodus/Entities/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
+++ b/Resources/Prototypes/_Exodus/Entities/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
@@ -7,15 +7,6 @@
   suffix: Large, T4
   description: A single-barrel 220mm autocannon for sustained automatic fire. Fires 220mm auto shells with slightly reduced brute strength. Can be remotely activated or linked up to a GCS.
   components:
-  - type: Anchorable
-    delay: 10
-  - type: Rotatable
-    rotateWhilePulling: false
-    rotateWhileAnchored: false
-    increment: 90
-  - type: Pullable
-  - type: PirateBountyItem
-    id: ShipWeapon
   - type: Sprite
     sprite: _Exodus/Objects/ShuttleWeapons/typhon.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
@@ -5,7 +5,7 @@
   id: WeaponTurretCyrexa
   name: CYREXA 220mm cannon
   parent:
-  - BallisticArtilleryUnanchorableCartridge
+  - BallisticArtilleryCartridge # Exodus turret-anchorable (no RequiresGrid)
   - ShipGunTier4HpExploding # Exodus self-destruct (HP, was BallisticArtilleryTier4HP)
   - ShipGunExplodes5x5 # Exodus self-destruct (blast size)
   suffix: Large, T4
@@ -89,7 +89,7 @@
   id: WeaponTurretBofors
   name: Bofors 255mm cannon
   parent:
-  - BallisticArtilleryUnanchorableCartridge
+  - BallisticArtilleryCartridge # Exodus turret-anchorable (no RequiresGrid)
   - ShipGunTier4HpExploding # Exodus self-destruct (HP, was BallisticArtilleryTier4HP)
   - ShipGunExplodes5x5 # Exodus self-destruct (blast size)
   suffix: Large, T4

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
@@ -155,7 +155,7 @@
   name: Hydra 220mm battery
   suffix: Large, T3
   parent:
-  - BallisticArtilleryUnanchorable
+  - BallisticArtillery # Exodus turret-anchorable (no RequiresGrid)
   - ShipGunExplodes5x5 # Exodus self-destruct (blast size only; HP/armor stay unique below)
   description: A main cannonade of syndicate origin, the hydra is a monstrous tri-barreled battery of 220-millimeter pain, designed to shatter corpations' toughest vessels. Loads with a similar mechanism as the anaconda handgun.
   components:


### PR DESCRIPTION
## Описание PR
Добавил возможность скручивать Гидры, Бофорсы, Цирексы.

## Почему / Баланс
Отходим от духотиловы. Тем более у нас пушки взрываются, так что проблем не вижу.

## Технические детали
Убрал лишние объявления у Тифона, ибо он наследуется от Цирексы.

## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения


**Список изменений**
:cl:
- tweak: Гидры, Бофорсы и Цирексы теперь можно скрутить и спокойно установить на свой корабль.
