### PR TITLE
Fix: Multi-hand Hittinid grabbing/carrying fix

### DIFF
--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -117,7 +117,14 @@ public sealed partial class EscapeInventorySystem : EntitySystem
 
         if (TryComp<BeingCarriedComponent>(uid, out var carried)) // Start of carrying system of nyanotrasen.
         {
-            _carryingSystem.DropCarried(carried.Carrier, uid);
+            // Exodus-begin: multi-carry
+            if (carried.Carrier.IsValid() && !TerminatingOrDeleted(carried.Carrier))
+                _carryingSystem.DropCarried(carried.Carrier, uid);
+            else
+                _carryingSystem.CleanupCarriedVictim(uid);
+
+            args.Handled = true;
+            // Exodus-end
             return;
         } // End of carrying system of nyanotrasen.
 

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -110,9 +110,7 @@ public sealed partial class EscapeInventorySystem : EntitySystem
     {
         component.DoAfter = null;
 
-        // Exodus-begin: always clear the cancel action when the escape do-after ends, even on cancellation.
-        RemoveCancelAction(uid, component); // Frontier
-        // Exodus-end
+        RemoveCancelAction(uid, component); // Exodus always clear the cancel action when the escape do-after ends, even on cancellation.
 
         if (args.Handled || args.Cancelled)
             return;

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -120,7 +120,7 @@ public sealed partial class EscapeInventorySystem : EntitySystem
         if (TryComp<BeingCarriedComponent>(uid, out var carried)) // Start of carrying system of nyanotrasen.
         {
             // Exodus-begin: multi-carry
-            if (carried.Carrier.IsValid() && !TerminatingOrDeleted(carried.Carrier))
+            if (!TerminatingOrDeleted(carried.Carrier))
                 _carryingSystem.DropCarried(carried.Carrier, uid);
             else
                 _carryingSystem.CleanupCarriedVictim(uid);

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -110,10 +110,12 @@ public sealed partial class EscapeInventorySystem : EntitySystem
     {
         component.DoAfter = null;
 
+        // Exodus-begin: always clear the cancel action when the escape do-after ends, even on cancellation.
+        RemoveCancelAction(uid, component); // Frontier
+        // Exodus-end
+
         if (args.Handled || args.Cancelled)
             return;
-
-        RemoveCancelAction(uid, component); // Frontier
 
         if (TryComp<BeingCarriedComponent>(uid, out var carried)) // Start of carrying system of nyanotrasen.
         {

--- a/Content.Server/_EE/Carrying/CarriableComponent.cs
+++ b/Content.Server/_EE/Carrying/CarriableComponent.cs
@@ -9,8 +9,12 @@ namespace Content.Server.Carrying
         ///     Number of free hands required
         ///     to carry the entity
         /// </summary>
+        // Exodus-begin: multi-carry
+        public const int DefaultFreeHandsRequired = 2;
+
         [DataField]
-        public int FreeHandsRequired = 2;
+        public int FreeHandsRequired = DefaultFreeHandsRequired;
+        // Exodus-end
 
         public CancellationTokenSource? CancelToken;
 

--- a/Content.Server/_EE/Carrying/CarryingComponent.cs
+++ b/Content.Server/_EE/Carrying/CarryingComponent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic; // Exodus multi-carry
+
 namespace Content.Server.Carrying
 {
     /// <summary>
@@ -6,6 +8,11 @@ namespace Content.Server.Carrying
     [RegisterComponent]
     public sealed partial class CarryingComponent : Component
     {
-        public EntityUid Carried = default!;
+        // Exodus-begin: multi-carry
+        /// <summary>
+        /// Every entity currently being carried by this mob.
+        /// </summary>
+        public HashSet<EntityUid> Carried = new();
+        // Exodus-end
     }
 }

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -131,12 +131,13 @@ namespace Content.Server.Carrying
         /// <summary>
         /// Since the carried entity is stored as virtual items per <see cref="CarriableComponent.FreeHandsRequired"/>, when deleted we want to drop them.
         /// </summary>
-        private void OnVirtualItemDeleted(EntityUid uid, CarryingComponent component, VirtualItemDeletedEvent args)
+        private void OnVirtualItemDeleted(Entity<CarryingComponent> ent, ref VirtualItemDeletedEvent args)
         {
-            if (!HasComp<CarriableComponent>(args.BlockingEntity))
+            if (!HasComp<CarriableComponent>(args.BlockingEntity)
+                || !ent.Comp.Carried.Contains(args.BlockingEntity))
                 return;
 
-            DropCarried(uid, args.BlockingEntity);
+            DropCarried(ent, args.BlockingEntity);
         }
 
         /// <summary>
@@ -345,17 +346,18 @@ namespace Content.Server.Carrying
             if (!carrier.IsValid() || TerminatingOrDeleted(carrier))
                 return;
 
-            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
-
             if (!TryComp<CarryingComponent>(carrier, out var carrying))
             {
                 _movementSpeed.RefreshMovementSpeedModifiers(carrier);
-                return;
+            }
+            else
+            {
+                carrying.Carried.Remove(carried);
+                PruneCarried((carrier, carrying));
+                FinalizeCarryingState((carrier, carrying));
             }
 
-            carrying.Carried.Remove(carried);
-            PruneCarried((carrier, carrying));
-            FinalizeCarryingState((carrier, carrying));
+            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
         }
 
         /// <summary>

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -54,7 +54,6 @@ namespace Content.Server.Carrying
         [Dependency] private TransformSystem _transform = default!;
 
         private readonly List<(EntityUid Carrier, EntityUid Carried)> _pendingDrops = new(); // Exodus multi-carry
-        private readonly List<EntityUid> _pruneBuffer = new(); // Exodus multi-carry
 
         public const float BaseDistanceCoeff = 0.5f; // Frontier: default throwing speed reduction
         public const float MaxDistanceCoeff = 1.0f; // Frontier: default throwing speed reduction
@@ -181,14 +180,9 @@ namespace Content.Server.Carrying
 
         private void OnCarrierTerminating(Entity<CarryingComponent> ent, ref Robust.Shared.GameObjects.EntityTerminatingEvent args)
         {
-            _pruneBuffer.Clear();
+            var carriedList = new List<EntityUid>(ent.Comp.Carried);
 
-            foreach (var carried in ent.Comp.Carried)
-            {
-                _pruneBuffer.Add(carried);
-            }
-
-            foreach (var carried in _pruneBuffer)
+            foreach (var carried in carriedList)
             {
                 CleanupCarriedVictim(carried);
             }
@@ -267,14 +261,14 @@ namespace Content.Server.Carrying
         }
         // Exodus-end
 
-        private void OnDoAfter(EntityUid uid, CarriableComponent component, CarryDoAfterEvent args)
+        private void OnDoAfter(Entity<CarriableComponent> ent, ref CarryDoAfterEvent args) // Exodus: modern event signature
         {
-            component.CancelToken = null;
+            ent.Comp.CancelToken = null;
             if (args.Handled || args.Cancelled
-                || !CanCarry(args.Args.User, uid, component))
+                || !CanCarry(args.Args.User, ent.Owner, ent.Comp))
                 return;
 
-            if (Carry(args.Args.User, (uid, component))) // Exodus multi-carry
+            if (Carry(args.Args.User, ent)) // Exodus multi-carry
                 args.Handled = true;
         }
 
@@ -376,7 +370,7 @@ namespace Content.Server.Carrying
         /// </summary>
         public void CleanupCarriedVictim(EntityUid carried)
         {
-            if (!carried.IsValid() || TerminatingOrDeleted(carried))
+            if (TerminatingOrDeleted(carried))
                 return;
 
             // Exodus: remove immediately so that StandAttempt / UpdateCanMove see the blockers gone.
@@ -394,7 +388,7 @@ namespace Content.Server.Carrying
 
         private void RemoveCarriedFromCarrier(EntityUid carrier, EntityUid carried)
         {
-            if (!carrier.IsValid() || TerminatingOrDeleted(carrier))
+            if (TerminatingOrDeleted(carrier))
                 return;
 
             if (!TryComp<CarryingComponent>(carrier, out var carrying))
@@ -478,16 +472,14 @@ namespace Content.Server.Carrying
 
         private void PruneCarried(Entity<CarryingComponent> carrying)
         {
-            _pruneBuffer.Clear();
+            carrying.Comp.Carried.RemoveWhere(TerminatingOrDeleted);
 
-            foreach (var uid in carrying.Comp.Carried)
-            {
-                if (!uid.IsValid() || TerminatingOrDeleted(uid))
-                    _pruneBuffer.Add(uid);
-            }
+            if (carrying.Comp.Carried.Count != 0)
+                return;
 
-            foreach (var uid in _pruneBuffer)
-                carrying.Comp.Carried.Remove(uid);
+            RemCompDeferred<CarryingComponent>(carrying);
+            RemComp<CarryingSlowdownComponent>(carrying);
+            _movementSpeed.RefreshMovementSpeedModifiers(carrying.Owner);
         }
 
         private void FinalizeCarryingState(Entity<CarryingComponent> carrying)
@@ -555,7 +547,7 @@ namespace Content.Server.Carrying
                     continue;
 
                 // Exodus-begin: multi-carry
-                if (carrier is not { Valid: true } || TerminatingOrDeleted(carrier))
+                if (TerminatingOrDeleted(carrier))
                 {
                     _pendingDrops.Add((EntityUid.Invalid, carried));
                     continue;

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -69,6 +69,7 @@ namespace Content.Server.Carrying
             SubscribeLocalEvent<CarryingComponent, BeforeThrowEvent>(OnThrow);
             SubscribeLocalEvent<CarryingComponent, EntParentChangedMessage>(OnParentChanged); // Exodus multi-carry
             SubscribeLocalEvent<CarryingComponent, MobStateChangedEvent>(OnMobStateChanged); // Exodus multi-carry
+            SubscribeLocalEvent<CarryingComponent, Robust.Shared.GameObjects.EntityTerminatingEvent>(OnCarrierTerminating); // Exodus multi-carry cleanup
             SubscribeLocalEvent<BeingCarriedComponent, InteractionAttemptEvent>(OnInteractionAttempt);
             SubscribeLocalEvent<BeingCarriedComponent, MoveInputEvent>(OnMoveInput);
             SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnMoveAttempt);
@@ -80,6 +81,7 @@ namespace Content.Server.Carrying
             SubscribeLocalEvent<BeingCarriedComponent, UnbuckledEvent>(OnBuckleChange);
             SubscribeLocalEvent<BeingCarriedComponent, StrappedEvent>(OnBuckleChange);
             SubscribeLocalEvent<BeingCarriedComponent, UnstrappedEvent>(OnBuckleChange);
+            SubscribeLocalEvent<BeingCarriedComponent, Robust.Shared.GameObjects.EntityTerminatingEvent>(OnCarriedTerminating); // Exodus multi-carry cleanup
             SubscribeLocalEvent<CarriableComponent, CarryDoAfterEvent>(OnDoAfter);
         }
 
@@ -176,6 +178,23 @@ namespace Content.Server.Carrying
         {
             DropAllCarried(ent);
         }
+
+        private void OnCarrierTerminating(Entity<CarryingComponent> ent, ref Robust.Shared.GameObjects.EntityTerminatingEvent args)
+        {
+            _pruneBuffer.Clear();
+
+            foreach (var carried in ent.Comp.Carried)
+            {
+                _pruneBuffer.Add(carried);
+            }
+
+            foreach (var carried in _pruneBuffer)
+            {
+                CleanupCarriedVictim(carried);
+            }
+
+            ent.Comp.Carried.Clear();
+        }
         // Exodus-end
 
         /// <summary>
@@ -240,6 +259,13 @@ namespace Content.Server.Carrying
         {
             DropCarried(component.Carrier, uid);
         }
+
+        // Exodus-begin: multi-carry cleanup
+        private void OnCarriedTerminating(Entity<BeingCarriedComponent> ent, ref Robust.Shared.GameObjects.EntityTerminatingEvent args)
+        {
+            RemoveCarriedFromCarrier(ent.Comp.Carrier, ent.Owner);
+        }
+        // Exodus-end
 
         private void OnDoAfter(EntityUid uid, CarriableComponent component, CarryDoAfterEvent args)
         {
@@ -342,22 +368,7 @@ namespace Content.Server.Carrying
         public void DropCarried(EntityUid carrier, EntityUid carried)
         {
             CleanupCarriedVictim(carried);
-
-            if (!carrier.IsValid() || TerminatingOrDeleted(carrier))
-                return;
-
-            if (!TryComp<CarryingComponent>(carrier, out var carrying))
-            {
-                _movementSpeed.RefreshMovementSpeedModifiers(carrier);
-            }
-            else
-            {
-                carrying.Carried.Remove(carried);
-                PruneCarried((carrier, carrying));
-                FinalizeCarryingState((carrier, carrying));
-            }
-
-            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
+            RemoveCarriedFromCarrier(carrier, carried);
         }
 
         /// <summary>
@@ -375,10 +386,29 @@ namespace Content.Server.Carrying
 
             _actionBlockerSystem.UpdateCanMove(carried);
             _transform.AttachToGridOrMap(carried);
-            _standingState.Stand(carried, force: true);
+            _standingState.Stand(carried);
 
             if (TryComp<CanEscapeInventoryComponent>(carried, out var escape) && escape.DoAfter != null)
                 _doAfterSystem.Cancel(escape.DoAfter);
+        }
+
+        private void RemoveCarriedFromCarrier(EntityUid carrier, EntityUid carried)
+        {
+            if (!carrier.IsValid() || TerminatingOrDeleted(carrier))
+                return;
+
+            if (!TryComp<CarryingComponent>(carrier, out var carrying))
+            {
+                RemComp<CarryingSlowdownComponent>(carrier);
+                _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+                _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
+                return;
+            }
+
+            carrying.Carried.Remove(carried);
+            PruneCarried((carrier, carrying));
+            FinalizeCarryingState((carrier, carrying));
+            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
         }
 
         private void DropAllCarried(Entity<CarryingComponent> carrier)

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -472,7 +472,7 @@ namespace Content.Server.Carrying
 
         private void PruneCarried(Entity<CarryingComponent> carrying)
         {
-            carrying.Comp.Carried.RemoveWhere(TerminatingOrDeleted);
+            carrying.Comp.Carried.RemoveWhere(uid => TerminatingOrDeleted(uid));
 
             if (carrying.Comp.Carried.Count != 0)
                 return;

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -110,7 +110,9 @@ namespace Content.Server.Carrying
             // If the person is carrying someone, and the carried person is a pseudo-item, and the target entity is a storage,
             // then add an action to insert the carried entity into the target
             var toInsert = args.Using;
+            // Exodus multi-carry: Using can be any free-hand item; only act on entities actually being carried.
             if (toInsert is not { Valid: true } || !args.CanAccess
+                || !component.Carried.Contains(toInsert.Value)
                 || !TryComp<PseudoItemComponent>(toInsert, out var pseudoItem)
                 || !TryComp<StorageComponent>(args.Target, out var storageComp)
                 || !_pseudoItem.CheckItemFits((toInsert.Value, pseudoItem), (args.Target, storageComp)))
@@ -147,8 +149,10 @@ namespace Content.Server.Carrying
         /// </summary>
         private void OnThrow(EntityUid uid, CarryingComponent component, ref BeforeThrowEvent args)
         {
+            // Exodus multi-carry: pull also creates virtual items for carriable entities; only remap throws for carried ones.
             if (!TryComp<VirtualItemComponent>(args.ItemUid, out var virtItem)
-                || !HasComp<CarriableComponent>(virtItem.BlockingEntity))
+                || !HasComp<CarriableComponent>(virtItem.BlockingEntity)
+                || !component.Carried.Contains(virtItem.BlockingEntity))
                 return;
 
             args.ItemUid = virtItem.BlockingEntity;

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic; // Exodus multi-carry
 using System.Numerics;
 using System.Threading;
 using Content.Server.DoAfter;
@@ -28,6 +29,7 @@ using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nyanotrasen.Item.PseudoItem;
+using Content.Shared.Resist; // Exodus
 using Content.Shared.Storage;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
@@ -51,6 +53,9 @@ namespace Content.Server.Carrying
         [Dependency] private ContestsSystem _contests = default!;
         [Dependency] private TransformSystem _transform = default!;
 
+        private readonly List<(EntityUid Carrier, EntityUid Carried)> _pendingDrops = new(); // Exodus multi-carry
+        private readonly List<EntityUid> _pruneBuffer = new(); // Exodus multi-carry
+
         public const float BaseDistanceCoeff = 0.5f; // Frontier: default throwing speed reduction
         public const float MaxDistanceCoeff = 1.0f; // Frontier: default throwing speed reduction
         public const float DefaultMaxThrowDistance = 4.0f; // Frontier: maximum throwing distance
@@ -62,8 +67,8 @@ namespace Content.Server.Carrying
             SubscribeLocalEvent<CarryingComponent, GetVerbsEvent<InnateVerb>>(AddInsertCarriedVerb);
             SubscribeLocalEvent<CarryingComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
             SubscribeLocalEvent<CarryingComponent, BeforeThrowEvent>(OnThrow);
-            SubscribeLocalEvent<CarryingComponent, EntParentChangedMessage>(OnParentChanged);
-            SubscribeLocalEvent<CarryingComponent, MobStateChangedEvent>(OnMobStateChanged);
+            SubscribeLocalEvent<CarryingComponent, EntParentChangedMessage>(OnParentChanged); // Exodus multi-carry
+            SubscribeLocalEvent<CarryingComponent, MobStateChangedEvent>(OnMobStateChanged); // Exodus multi-carry
             SubscribeLocalEvent<BeingCarriedComponent, InteractionAttemptEvent>(OnInteractionAttempt);
             SubscribeLocalEvent<BeingCarriedComponent, MoveInputEvent>(OnMoveInput);
             SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnMoveAttempt);
@@ -80,9 +85,9 @@ namespace Content.Server.Carrying
 
         private void AddCarryVerb(EntityUid uid, CarriableComponent component, GetVerbsEvent<AlternativeVerb> args)
         {
+            // Exodus multi-carry: no longer block when CarryingComponent exists; CanCarry checks free hands.
             if (!args.CanInteract || !args.CanAccess || !_mobStateSystem.IsAlive(args.User)
                 || !CanCarry(args.User, uid, component)
-                || HasComp<CarryingComponent>(args.User)
                 || HasComp<BeingCarriedComponent>(args.User) || HasComp<BeingCarriedComponent>(args.Target)
                 || args.User == args.Target)
                 return;
@@ -124,7 +129,7 @@ namespace Content.Server.Carrying
         }
 
         /// <summary>
-        /// Since the carried entity is stored as 2 virtual items, when deleted we want to drop them.
+        /// Since the carried entity is stored as virtual items per <see cref="CarriableComponent.FreeHandsRequired"/>, when deleted we want to drop them.
         /// </summary>
         private void OnVirtualItemDeleted(EntityUid uid, CarryingComponent component, VirtualItemDeletedEvent args)
         {
@@ -156,19 +161,21 @@ namespace Content.Server.Carrying
             // End Frontier
         }
 
-        private void OnParentChanged(EntityUid uid, CarryingComponent component, ref EntParentChangedMessage args)
+        // Exodus-begin: multi-carry
+        private void OnParentChanged(Entity<CarryingComponent> ent, ref EntParentChangedMessage args)
         {
-            var xform = Transform(uid);
+            var xform = Transform(ent);
             if (xform.MapUid != args.OldMapId || xform.ParentUid == xform.GridUid)
                 return;
 
-            DropCarried(uid, component.Carried);
+            DropAllCarried(ent);
         }
 
-        private void OnMobStateChanged(EntityUid uid, CarryingComponent component, MobStateChangedEvent args)
+        private void OnMobStateChanged(Entity<CarryingComponent> ent, ref MobStateChangedEvent args)
         {
-            DropCarried(uid, component.Carried);
+            DropAllCarried(ent);
         }
+        // Exodus-end
 
         /// <summary>
         /// Only let the person being carried interact with their carrier and things on their person.
@@ -240,9 +247,10 @@ namespace Content.Server.Carrying
                 || !CanCarry(args.Args.User, uid, component))
                 return;
 
-            Carry(args.Args.User, uid);
-            args.Handled = true;
+            if (Carry(args.Args.User, (uid, component))) // Exodus multi-carry
+                args.Handled = true;
         }
+
         private void StartCarryDoAfter(EntityUid carrier, EntityUid carried, CarriableComponent component)
         {
             if (!TryComp<PhysicsComponent>(carrier, out var carrierPhysics)
@@ -275,13 +283,18 @@ namespace Content.Server.Carrying
                 MultiplyDelay = false, // Goobstation
             };
 
-            _doAfterSystem.TryStartDoAfter(args);
+            if (!_doAfterSystem.TryStartDoAfter(args)) // Exodus multi-carry
+            {
+                component.CancelToken = null;
+                return;
+            }
 
             // Show a popup to the person getting picked up
             _popupSystem.PopupEntity(Loc.GetString("carry-started", ("carrier", carrier)), carried, carried);
         }
 
-        private void Carry(EntityUid carrier, EntityUid carried)
+        // Exodus-begin: multi-carry
+        private bool Carry(EntityUid carrier, Entity<CarriableComponent> carried)
         {
             if (TryComp<PullableComponent>(carried, out var pullable))
                 _pullingSystem.TryStopPull(carried, pullable);
@@ -291,18 +304,24 @@ namespace Content.Server.Carrying
             _transform.SetCoordinates(carried, Transform(carrier).Coordinates);
             _transform.SetParent(carried, carrier);
 
-            _virtualItemSystem.TrySpawnVirtualItemInHand(carried, carrier);
-            _virtualItemSystem.TrySpawnVirtualItemInHand(carried, carrier);
+            if (!TrySpawnCarryVirtualItems(carried, carrier))
+            {
+                _transform.AttachToGridOrMap(carried);
+                return false;
+            }
+
             var carryingComp = EnsureComp<CarryingComponent>(carrier);
-            ApplyCarrySlowdown(carrier, carried);
             var carriedComp = EnsureComp<BeingCarriedComponent>(carried);
             EnsureComp<KnockedDownComponent>(carried);
 
-            carryingComp.Carried = carried;
+            carryingComp.Carried.Add(carried);
             carriedComp.Carrier = carrier;
 
+            RecalculateCarrySlowdown((carrier, carryingComp));
             _actionBlockerSystem.UpdateCanMove(carried);
+            return true;
         }
+        // Exodus-end
 
         public bool TryCarry(EntityUid carrier, EntityUid toCarry, CarriableComponent? carriedComp = null)
         {
@@ -315,34 +334,142 @@ namespace Content.Server.Carrying
                 && carrierPhysics.Mass < toCarryPhysics.Mass * 2f)
                 return false;
 
-            Carry(carrier, toCarry);
+            return Carry(carrier, (toCarry, carriedComp)); // Exodus multi-carry
+        }
+
+        // Exodus-begin: multi-carry
+        public void DropCarried(EntityUid carrier, EntityUid carried)
+        {
+            CleanupCarriedVictim(carried);
+
+            if (!carrier.IsValid() || TerminatingOrDeleted(carrier))
+                return;
+
+            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
+
+            if (!TryComp<CarryingComponent>(carrier, out var carrying))
+            {
+                _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+                return;
+            }
+
+            carrying.Carried.Remove(carried);
+            PruneCarried((carrier, carrying));
+            FinalizeCarryingState((carrier, carrying));
+        }
+
+        /// <summary>
+        /// Clears carry state on the victim when the carrier is missing or deleted.
+        /// </summary>
+        public void CleanupCarriedVictim(EntityUid carried)
+        {
+            if (!carried.IsValid() || TerminatingOrDeleted(carried))
+                return;
+
+            RemCompDeferred<BeingCarriedComponent>(carried);
+            RemCompDeferred<KnockedDownComponent>(carried);
+            _actionBlockerSystem.UpdateCanMove(carried);
+            _transform.AttachToGridOrMap(carried);
+            _standingState.Stand(carried);
+
+            if (TryComp<CanEscapeInventoryComponent>(carried, out var escape) && escape.DoAfter != null)
+                _doAfterSystem.Cancel(escape.DoAfter);
+        }
+
+        private void DropAllCarried(Entity<CarryingComponent> carrier)
+        {
+            PruneCarried(carrier);
+
+            if (carrier.Comp.Carried.Count == 0)
+            {
+                RemComp<CarryingComponent>(carrier);
+                RemComp<CarryingSlowdownComponent>(carrier);
+                _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+                return;
+            }
+
+            while (carrier.Comp.Carried.Count > 0)
+            {
+                using var enumerator = carrier.Comp.Carried.GetEnumerator();
+                enumerator.MoveNext();
+                DropCarried(carrier, enumerator.Current);
+            }
+
+            if (TryComp<CarryingComponent>(carrier, out var carrying))
+                FinalizeCarryingState((carrier, carrying));
+        }
+
+        private bool TrySpawnCarryVirtualItems(Entity<CarriableComponent> carried, EntityUid carrier)
+        {
+            for (var i = 0; i < carried.Comp.FreeHandsRequired; i++)
+            {
+                if (_virtualItemSystem.TrySpawnVirtualItemInHand(carried, carrier))
+                    continue;
+
+                _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
+                return false;
+            }
 
             return true;
         }
 
-        public void DropCarried(EntityUid carrier, EntityUid carried)
+        private void RecalculateCarrySlowdown(Entity<CarryingComponent> carrying)
         {
-            RemComp<CarryingComponent>(carrier); // get rid of this first so we don't recursively fire that event
-            RemComp<CarryingSlowdownComponent>(carrier);
-            RemComp<BeingCarriedComponent>(carried);
-            RemComp<KnockedDownComponent>(carried);
-            _actionBlockerSystem.UpdateCanMove(carried);
-            _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
-            _transform.AttachToGridOrMap(carried);
-            _standingState.Stand(carried);
-            _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+            PruneCarried(carrying);
+
+            if (carrying.Comp.Carried.Count == 0)
+            {
+                RemComp<CarryingSlowdownComponent>(carrying);
+                _movementSpeed.RefreshMovementSpeedModifiers(carrying.Owner);
+                return;
+            }
+
+            var walkModifier = 1f;
+            var sprintModifier = 1f;
+
+            foreach (var carried in carrying.Comp.Carried)
+            {
+                var massRatio = _contests.MassContest(carrying.Owner, carried, true);
+                var massRatioSq = massRatio * massRatio;
+                var modifier = 1 - 0.15f / massRatioSq;
+                modifier = Math.Max(0.1f, modifier);
+                walkModifier *= modifier;
+                sprintModifier *= modifier;
+            }
+
+            var slowdownComp = EnsureComp<CarryingSlowdownComponent>(carrying);
+            _slowdown.SetModifier(carrying.Owner, walkModifier, sprintModifier, slowdownComp);
         }
 
-        private void ApplyCarrySlowdown(EntityUid carrier, EntityUid carried)
+        private void PruneCarried(Entity<CarryingComponent> carrying)
         {
-            var massRatio = _contests.MassContest(carrier, carried, true);
-            var massRatioSq = MathF.Pow(massRatio, 2);
-            var modifier = 1 - 0.15f / massRatioSq;
-            modifier = Math.Max(0.1f, modifier);
+            _pruneBuffer.Clear();
 
-            var slowdownComp = EnsureComp<CarryingSlowdownComponent>(carrier);
-            _slowdown.SetModifier(carrier, modifier, modifier, slowdownComp);
+            foreach (var uid in carrying.Comp.Carried)
+            {
+                if (!uid.IsValid() || TerminatingOrDeleted(uid))
+                    _pruneBuffer.Add(uid);
+            }
+
+            foreach (var uid in _pruneBuffer)
+                carrying.Comp.Carried.Remove(uid);
         }
+
+        private void FinalizeCarryingState(Entity<CarryingComponent> carrying)
+        {
+            if (carrying.Comp.Carried.Count == 0)
+            {
+                RemComp<CarryingComponent>(carrying);
+                RemComp<CarryingSlowdownComponent>(carrying);
+            }
+            else
+            {
+                RecalculateCarrySlowdown(carrying);
+            }
+
+            _movementSpeed.RefreshMovementSpeedModifiers(carrying);
+        }
+        // Exodus-end
 
         public bool CanCarry(EntityUid carrier, EntityUid carried, CarriableComponent? carriedComp = null)
         {
@@ -351,38 +478,83 @@ namespace Content.Server.Carrying
                 || !HasComp<MapGridComponent>(Transform(carrier).ParentUid)
                 || HasComp<BeingCarriedComponent>(carrier)
                 || HasComp<BeingCarriedComponent>(carried)
-                || !TryComp<HandsComponent>(carrier, out var hands)
-                || hands.CountFreeHands() < carriedComp.FreeHandsRequired)
+                || !TryComp<HandsComponent>(carrier, out var hands))
                 return false;
+
+            // Exodus-begin: multi-carry
+            if (TryComp<CarryingComponent>(carrier, out var carrying))
+                PruneCarried((carrier, carrying));
+
+            if (CountFreeHands(hands) < carriedComp.FreeHandsRequired)
+                return false;
+            // Exodus-end
 
             return true;
         }
 
+        // Exodus-begin: multi-carry
+        private static int CountFreeHands(HandsComponent hands)
+        {
+            var free = 0;
+
+            foreach (var hand in hands.Hands.Values)
+            {
+                if (hand.IsEmpty)
+                    free++;
+            }
+
+            return free;
+        }
+        // Exodus-end
+
         public override void Update(float frameTime)
         {
+            _pendingDrops.Clear(); // Exodus multi-carry
+
             var query = EntityQueryEnumerator<BeingCarriedComponent>();
             while (query.MoveNext(out var carried, out var comp))
             {
                 var carrier = comp.Carrier;
-                if (carrier is not { Valid: true } || carried is not { Valid: true })
+
+                if (carried is not { Valid: true })
                     continue;
+
+                // Exodus-begin: multi-carry
+                if (carrier is not { Valid: true } || TerminatingOrDeleted(carrier))
+                {
+                    _pendingDrops.Add((EntityUid.Invalid, carried));
+                    continue;
+                }
+                // Exodus-end
 
                 // SOMETIMES - when an entity is inserted into disposals, or a cryosleep chamber - it can get re-parented without a proper reparent event
                 // when this happens, it needs to be dropped because it leads to weird behavior
-                if (Transform(carried).ParentUid != carrier)
+                // Exodus-begin: multi-carry
+                var xform = Transform(carried);
+                if (xform.ParentUid != carrier)
                 {
-                    DropCarried(carrier, carried);
+                    _pendingDrops.Add((carrier, carried));
                     continue;
                 }
+                // Exodus-end
 
                 // Make sure the carried entity is always centered relative to the carrier, as gravity pulls can offset it otherwise
-                var xform = Transform(carried);
                 if (!xform.LocalPosition.Equals(Vector2.Zero))
                 {
                     xform.LocalPosition = Vector2.Zero;
                 }
             }
             query.Dispose();
+
+            // Exodus-begin: multi-carry
+            foreach (var (carrier, carried) in _pendingDrops)
+            {
+                if (carrier.IsValid())
+                    DropCarried(carrier, carried);
+                else
+                    CleanupCarriedVictim(carried);
+            }
+            // Exodus-end
         }
     }
 }

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -368,11 +368,14 @@ namespace Content.Server.Carrying
             if (!carried.IsValid() || TerminatingOrDeleted(carried))
                 return;
 
-            RemCompDeferred<BeingCarriedComponent>(carried);
-            RemCompDeferred<KnockedDownComponent>(carried);
+            // Exodus: remove immediately so that StandAttempt / UpdateCanMove see the blockers gone.
+            // Deferred removal left BeingCarried/KnockedDown active during re-enable, causing permanent no-move after drop.
+            RemComp<BeingCarriedComponent>(carried);
+            RemComp<KnockedDownComponent>(carried);
+
             _actionBlockerSystem.UpdateCanMove(carried);
             _transform.AttachToGridOrMap(carried);
-            _standingState.Stand(carried);
+            _standingState.Stand(carried, force: true);
 
             if (TryComp<CanEscapeInventoryComponent>(carried, out var escape) && escape.DoAfter != null)
                 _doAfterSystem.Cancel(escape.DoAfter);


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Система перетаскивания тел теперь работает с мультируками. Будь у вашей куклы 4,6,8, или даже 10 ладошек - вы сможете перетаскивать соответствующее количество тел. (2 руки=одно тело)

## Почему / Баланс
Довольно резонно, что количество рук предопределяет количество перетаскиваемого.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Многорукие сущности теперь могут перетаскивать несколько тел без глитчей и багов.
