### PR TITLE
arrow bugfix 

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -159,6 +159,12 @@ public sealed partial class ProjectileSystem : SharedProjectileSystem
             if (comp.ProjectileSpent || TerminatingOrDeleted(uid))
                 continue;
 
+            // Exodus-Start
+            // we don't raycast inert projectiles
+            if (comp is { Weapon: null, OnlyCollideWhenShot: true })
+                continue;
+            // Exodus-End
+
             var xform = Transform(uid);
             var vel = comp.RaycastResetVelocity ?? _physics.GetMapLinearVelocity(uid, body, xform);
             var velLen = vel.Length();


### PR DESCRIPTION
На самом деле это фикс системы оптимизации рэйкаста от моно, которые при достижении проджом скорости 75 перестают считать физику а телепортируются(сеткоординатс) в цель. (как я понял). От этого тянулись баги с тем что эти болты нельзя было взять потому что у них велосити 0 но они летят.
Там нет проверок на выпущен ли снаряд, в контейнере ли он. 
Теперь не выпущенные болты вообще не попадают в рейкаст. 
багрепорт: https://discord.com/channels/1097181193939730453/1517587631960101086



теперь 

https://github.com/user-attachments/assets/fd4e2c6f-cf4e-4417-8aeb-85da46e8f1f0


- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

no cl no fun