### PR TITLE
walls protec wires

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -66,6 +66,8 @@ public sealed partial class ExplosionSystem
 
     private List<EntityUid> _anchored = new();
 
+    private readonly List<EntityUid> _subFloorDeferred = new(); // Exodus
+
     private void OnMapRemoved(MapRemovedEvent ev)
     {
         // If a map was deleted, check the explosion currently being processed belongs to that map.
@@ -235,9 +237,16 @@ public sealed partial class ExplosionSystem
         var tileBlocked = false;
         _anchored.Clear();
         _map.GetAnchoredEntities(grid, tile, _anchored);
+        _subFloorDeferred.Clear(); // Exodus
         foreach (var entity in _anchored)
         {
             processed.Add(entity);
+            if (_subFloorQuery.HasComponent(entity))
+            {
+                _subFloorDeferred.Add(entity);
+                continue;
+            }
+            // Exodus-End
             ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause);
         }
 
@@ -260,6 +269,13 @@ public sealed partial class ExplosionSystem
                 tileBlocked |= IsBlockingTurf(entity);
             }
         }
+
+        if (!tileBlocked)
+        {
+            foreach (var entity in _subFloorDeferred)
+                ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause);
+        }
+        // Exodus-End
 
         // Next, we get the intersecting entities AGAIN, but purely for throwing. This way, glass shards spawned from
         // windows will be flung outwards, and not stay where they spawned. This is however somewhat unnecessary, and a

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -241,6 +241,7 @@ public sealed partial class ExplosionSystem
         foreach (var entity in _anchored)
         {
             processed.Add(entity);
+            // Exodus-Start
             if (_subFloorQuery.HasComponent(entity))
             {
                 _subFloorDeferred.Add(entity);
@@ -270,6 +271,7 @@ public sealed partial class ExplosionSystem
             }
         }
 
+        // Exodus-Start
         if (!tileBlocked)
         {
             foreach (var entity in _subFloorDeferred)

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -32,6 +32,7 @@ using Robust.Shared.Utility;
 using Content.Shared.Maps;
 using Robust.Shared.Map.Components;
 using Content.Shared.Tiles; // Frontier: safe zone
+using Content.Shared.SubFloor; // Exodus
 using Robust.Shared.Timing; // Mono
 
 // Mono
@@ -76,6 +77,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     private EntityQuery<DestructibleComponent> _destructibleQuery;
     private EntityQuery<DamageableComponent> _damageableQuery;
     private EntityQuery<AirtightComponent> _airtightQuery;
+    private EntityQuery<SubFloorHideComponent> _subFloorQuery; // Exodus
 
     /// <summary>
     ///     "Tile-size" for space when there are no nearby grids to use as a reference.
@@ -132,6 +134,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         _destructibleQuery = GetEntityQuery<DestructibleComponent>();
         _damageableQuery = GetEntityQuery<DamageableComponent>();
         _airtightQuery = GetEntityQuery<AirtightComponent>();
+        _subFloorQuery = GetEntityQuery<SubFloorHideComponent>(); // Exodus
 
         _prototypeManager.PrototypesReloaded += ReloadExplosionPrototypes;
     }


### PR DESCRIPTION
Сто лет в обед надо было это сделать.
Дополнил логику защиты проводов от оффов, у них провода считаются защищёнными когда они закрыты плиткой, теперь провода считаются закрытыми тем что на плитке построено(стены+окна).

хватит это терпеть
<img width="1657" height="1355" alt="image" src="https://github.com/user-attachments/assets/83cfa7fd-f9db-4c31-8a0d-b75713e06ea9" />


- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

:cl: Lanc
- tweak: Провода под стенами больше не лопаются.