### PR TITLE
cryo expliot fix

### DIFF
--- a/Content.Client/_NF/CryoSleep/AcceptCryoWindow.cs
+++ b/Content.Client/_NF/CryoSleep/AcceptCryoWindow.cs
@@ -1,7 +1,10 @@
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Containers;
 using Robust.Shared.Localization;
+using Robust.Shared.Timing;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client._NF.CryoSleep;
@@ -10,8 +13,22 @@ public sealed class AcceptCryoWindow : DefaultWindow
     public readonly Button DenyButton;
     public readonly Button AcceptButton;
 
+    // Exodus-Start
+    private const string CryopodBodyContainerId = "body_container";
+    private const float CheckInterval = 1f; // seconds
+    private readonly IEntityManager _entMan;
+    private readonly IPlayerManager _player;
+    private readonly SharedContainerSystem _container;
+    private float _checkAccumulator;
+    // Exodus-End
+
     public AcceptCryoWindow()
     {
+        // Exodus-Start
+        _entMan = IoCManager.Resolve<IEntityManager>();
+        _player = IoCManager.Resolve<IPlayerManager>();
+        _container = _entMan.System<SharedContainerSystem>();
+        // Exodus-End
 
         Title = Loc.GetString("accept-cryo-window-title");
 
@@ -56,5 +73,23 @@ public sealed class AcceptCryoWindow : DefaultWindow
             }
         });
     }
+
+    // Exodus-Start
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        _checkAccumulator += args.DeltaSeconds;
+        if (_checkAccumulator < CheckInterval)
+            return;
+        _checkAccumulator = 0f;
+
+        if (_player.LocalEntity is not { } player
+            || !_container.TryGetContainingContainer((player, null, null), out var container)
+            || container.ID != CryopodBodyContainerId)
+        {
+            Close();
+        }
+    }
+    // Exodus-End
 }
 

--- a/Content.Client/_NF/CryoSleep/AcceptCryoWindow.cs
+++ b/Content.Client/_NF/CryoSleep/AcceptCryoWindow.cs
@@ -1,10 +1,7 @@
-using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
-using Robust.Shared.Containers;
 using Robust.Shared.Localization;
-using Robust.Shared.Timing;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client._NF.CryoSleep;
@@ -13,22 +10,8 @@ public sealed class AcceptCryoWindow : DefaultWindow
     public readonly Button DenyButton;
     public readonly Button AcceptButton;
 
-    // Exodus-Start
-    private const string CryopodBodyContainerId = "body_container";
-    private const float CheckInterval = 1f; // seconds
-    private readonly IEntityManager _entMan;
-    private readonly IPlayerManager _player;
-    private readonly SharedContainerSystem _container;
-    private float _checkAccumulator;
-    // Exodus-End
-
     public AcceptCryoWindow()
     {
-        // Exodus-Start
-        _entMan = IoCManager.Resolve<IEntityManager>();
-        _player = IoCManager.Resolve<IPlayerManager>();
-        _container = _entMan.System<SharedContainerSystem>();
-        // Exodus-End
 
         Title = Loc.GetString("accept-cryo-window-title");
 
@@ -73,23 +56,5 @@ public sealed class AcceptCryoWindow : DefaultWindow
             }
         });
     }
-
-    // Exodus-Start
-    protected override void FrameUpdate(FrameEventArgs args)
-    {
-        base.FrameUpdate(args);
-        _checkAccumulator += args.DeltaSeconds;
-        if (_checkAccumulator < CheckInterval)
-            return;
-        _checkAccumulator = 0f;
-
-        if (_player.LocalEntity is not { } player
-            || !_container.TryGetContainingContainer((player, null, null), out var container)
-            || container.ID != CryopodBodyContainerId)
-        {
-            Close();
-        }
-    }
-    // Exodus-End
 }
 

--- a/Content.Server/_NF/CryoSleep/CryoSleepEui.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepEui.cs
@@ -31,7 +31,10 @@ public sealed class CryoSleepEui : BaseEui
         {
             if (choice.Button == AcceptCryoUiButton.Accept)
             {
-                _cryoSystem.CryoStoreBody(_body, _cryopod);
+                // Exodus-Start
+                //_cryoSystem.CryoStoreBody(_body, _cryopod);
+                _cryoSystem.AcceptCryoSleep(_body, _cryopod);
+                // Exodus-End
             }
             else
             {

--- a/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
@@ -70,6 +70,7 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
     [Dependency] private StationSystem _station = default!;
 
     private readonly Dictionary<NetUserId, StoredBody?> _storedBodies = new();
+    private readonly Dictionary<EntityUid, CryoSleepEui> _openEuis = new(); // Exodus: body -> its open accept EUI, so it can be closed server-side.
     private EntityUid? _storageMap;
 
     public override void Initialize()
@@ -84,6 +85,7 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
         SubscribeLocalEvent<CryoSleepComponent, DestructionEventArgs>((e,c,_) => EjectBody(e, c));
         SubscribeLocalEvent<CryoSleepComponent, CryoStoreDoAfterEvent>(OnAutoCryoSleep);
         SubscribeLocalEvent<CryoSleepComponent, DragDropTargetEvent>(OnEntityDragDropped);
+        SubscribeLocalEvent<CryoSleepComponent, EntRemovedFromContainerMessage>(OnBodyRemoved); // Exodus
         SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
         SubscribeLocalEvent<RoleAddedEvent>(OnRoleAdded);
@@ -248,7 +250,12 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
 
         if (success && session != null)
         {
-            _euiManager.OpenEui(new CryoSleepEui(toInsert.Value,  cryopod, this), session);
+            // Exodus-Start
+            //_euiManager.OpenEui(new CryoSleepEui(toInsert.Value,  cryopod, this), session);
+            var eui = new CryoSleepEui(toInsert.Value, cryopod, this);
+            _euiManager.OpenEui(eui, session);
+            _openEuis[toInsert.Value] = eui;
+            // Exodus-End
         }
 
         if (success)
@@ -504,9 +511,30 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
         return component.BodyContainer.ContainedEntity != null;
     }
 
+    // Exodus-Start
+    public void AcceptCryoSleep(EntityUid body, EntityUid cryopod)
+    {
+        if (TryComp<CryoSleepComponent>(cryopod, out var cryo)
+            && cryo.BodyContainer.ContainedEntity == body)
+        {
+            CryoStoreBody(body, cryopod);
+        }
+    }
+
+    private void OnBodyRemoved(EntityUid uid, CryoSleepComponent component, EntRemovedFromContainerMessage args)
+    {
+        if (args.Container.ID != "body_container")
+            return;
+
+        if (_openEuis.Remove(args.Entity, out var eui))
+            eui.Close();
+    }
+    // Exodus-End
+
     private void OnRoundEnded(RoundEndedEvent args)
     {
         _storedBodies.Clear();
+        _openEuis.Clear(); // Exodus
     }
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)


### PR DESCRIPTION
Удивительно это не обнаружили раньше. 
Короче если залезть в крио, не закрыть промпт и пойти гулять, его можно потом нажать в любой момент и тепнуться в крио-капсулу. 
закрыл на клиенте, этого хватит. 

- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

:cl: Lanc
- fix: Исправлен эксплойт крио.