### PR TITLE
Asakim hot fixes

### DIFF
--- a/Resources/Maps/_Exodus/POI/whale.yml
+++ b/Resources/Maps/_Exodus/POI/whale.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 06/17/2026 10:49:13
-  entityCount: 2448
+  entityCount: 2449
 maps: []
 grids:
 - 1
@@ -14882,5 +14882,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,36.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 2449
+    components:
+    - type: Transform
+      pos: 0.5,6.5
       parent: 1
 ...

--- a/Resources/Prototypes/_Exodus/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Structures/Machines/shield_generator.yml
@@ -7,7 +7,7 @@
   components:
   - type: ShipShieldEmitter
     damageLimit: 1000000
-    healPerSecond: 800
+    healPerSecond: 1150
     damageExp: 1.05
     powerModifier: 0.10024
     baseDraw: 100000
@@ -161,6 +161,6 @@
   - type: ShipRepairable
     repairTime: 20
     repairCost: 125
-  - type: Anchorable 
+  - type: Anchorable
     flags:
     - None

--- a/Resources/Prototypes/_Exodus/PointsOfInterest/asakim.yml
+++ b/Resources/Prototypes/_Exodus/PointsOfInterest/asakim.yml
@@ -10,7 +10,7 @@
   addComponents:
   - type: IFF
     color: "#ff3db1"
-    readOnly: true
+    readOnly: false
 
 - type: gameMap
   id: ADSKashalot


### PR DESCRIPTION
## Описание PR
Увеличил реген щита МС-750 до 1150 вместо 800.

Добавил варп точку на кашалот.

Добавил возможность выключить опознавания у Кашалота

## Почему / Баланс
Мы нерфали щит МС-750 до 1 ляма. Пусть хотя бы он сможет полностью защитить от красной туманности + меньше времени на перезарядку щита.


## Технические детали


## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения

**Список изменений**
:cl: Renascitur
- Tweak: Скорость восстановления щита МС-750 увеличена. Теперь он восстанавливает щит быстрее. Защищен от красной туманности полностью.
- Fix: ВЭФ Кашалоту можно теперь можно отключить опознования.