### PR TITLE
Tweak: AI can be damaged

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -406,6 +406,7 @@
   - type: Anchorable
     flags:
     - Anchorable
+    - Unanchorable # Exodus: allow AI cores to be unanchored with a wrench
   - type: Rotatable
   #- type: WarpPoint # Mono - comment out
   #  blacklist:
@@ -414,11 +415,16 @@
   - type: ContainerComp
     proto: AiHeld
     container: station_ai_mind_slot
+  # Exodus-begin: AI core durability
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Electronic
+  # Exodus-end: AI core durability
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 1000 # Exodus: AI core durability
       behaviors:
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
## Описание PR
Ядра ИИ теперь могут быть уничтожены и скручены.
Раньше была ошибка, что их нельзя уничтожить. Она осталась, на неразрушаемых стенках, поэтому полу-мера в виде этого.

## Почему / Баланс

## Технические детали
Если ядро уничтожили, но игрок на ИИ контролировал борга, то он навсегда контролирует этого борга. Это допустимо и не является багом.

## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения


**Список изменений**
:cl:
- tweak: Ядра ИИ (игровые) теперь можно скрутить и уничтожить.