### PR TITLE
Fix: Neo-Russian back into loadout

### DIFF
--- a/Resources/Prototypes/_Mono/Traits/speech.yml
+++ b/Resources/Prototypes/_Mono/Traits/speech.yml
@@ -53,15 +53,16 @@
   languagesUnderstood:
   - Gary
 
-# - type: trait
-#   id: MonoNovaCygniBasic
-#   name: trait-language-NovaCygni-name
-#   description: trait-language-NovaCygni-desc
-#   category: LanguageTraits
-#   cost: 1
-#   components:
-#   - type: LanguageSpeaker
-#   languagesSpoken:
-#   - NovaCygniBasic
-#   languagesUnderstood:
-#   - NovaCygniBasic
+# Exodus restore Neo-Russian character trait removed upstream.
+- type: trait
+  id: MonoNovaCygniBasic
+  name: trait-language-NovaCygni-name
+  description: trait-language-NovaCygni-desc
+  category: LanguageTraits
+  cost: 1
+  components:
+  - type: LanguageSpeaker
+  languagesSpoken:
+  - NovaCygniBasic
+  languagesUnderstood:
+  - NovaCygniBasic


### PR DESCRIPTION
## Описание PR
Оффы удалили нео-русский из лодаута, раскоменчиваем его и возвращаем.

## Почему / Баланс

## Технические детали

## Медиа

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения


**Список изменений**
:cl:
- fix: Нео-Русский возвращен в лодаут. Не забудьте снова его выбрать для ваших персонажей.
