### PR TITLE
Fix: Deleting GasDeposits on tile destruction

### DIFF
--- a/Content.Server/Tiles/RequiresTileSystem.cs
+++ b/Content.Server/Tiles/RequiresTileSystem.cs
@@ -18,7 +18,8 @@ public sealed partial class RequiresTileSystem : EntitySystem
     {
         base.Initialize();
         _tilesQuery = GetEntityQuery<RequiresTileComponent>();
-        SubscribeLocalEvent<TileChangedEvent>(OnTileChange);
+        SubscribeLocalEvent<TileChangedEvent>(OnTileChange,
+            before: [typeof(SharedTransformSystem)]); // Exodus: delete before removed tiles deparent their entities
     }
 
     private void OnTileChange(ref TileChangedEvent ev)

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -16,6 +16,7 @@
   - type: Fixtures
   - type: GasDeposit
   - type: RandomGasDeposit
+  - type: RequiresTile # Exodus: remove deposits when their supporting asteroid tile is destroyed
   - type: Sprite
     drawdepth: FloorTiles
     sprite: _NF/Objects/Specific/Atmospherics/deposit.rsi


### PR DESCRIPTION
## Описание PR
Газовые жилы теперь удаляются если тайл под ними исчез.
Необходимо ввиду добавлении буров с оффов, которые уничтожали астероиды. Фикс, доедалово за оффами.

## Почему / Баланс


## Технические детали
Исправлена гонка RequiresTile при удалении тайлов. Точечный фикс.

## Медиа


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения


**Список изменений**
:cl:
- fix: Газовые жилы теперь удаляются если не находятся на тайле.