### PR TITLE
Borg production less cost

### DIFF
--- a/Resources/Prototypes/_Exodus/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_Exodus/Recipes/Lathes/robotics.yml
@@ -4,13 +4,13 @@
   result: CyborgEndoskeletonColossusSecurity
   completetime: 3
   materials:
-    Steel: 10000
-    Plasteel: 5000
-    Plastitanium: 4000
+    Steel: 8000
+    Plasteel: 1000
+    Plastitanium: 1000
     Plastic: 3000
     Gold: 2000
     Silver: 2000
-    Bluespace: 200
+    Bluespace: 100
     Diamond: 100
 
 - type: latheRecipe
@@ -19,13 +19,13 @@
   result: CyborgEndoskeletonPDV
   completetime: 3
   materials:
-    Steel: 10000
-    Plasteel: 5000
-    Plastitanium: 4000
+    Steel: 8000
+    Plasteel: 1000
+    Plastitanium: 1000
     Plastic: 3000
     Gold: 2000
     Silver: 2000
-    Bluespace: 200
+    Bluespace: 100
     Diamond: 100
 
 - type: latheRecipe
@@ -34,11 +34,11 @@
   result: CyborgEndoskeletonTSF
   completetime: 3
   materials:
-    Steel: 10000
-    Plasteel: 5000
-    Plastitanium: 4000
+    Steel: 8000
+    Plasteel: 1000
+    Plastitanium: 1000
     Plastic: 3000
     Gold: 2000
     Silver: 2000
-    Bluespace: 200
+    Bluespace: 100
     Diamond: 100

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/cyborg_parts.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/cyborg_parts.yml
@@ -6,13 +6,13 @@
   result: BorgIFFPDV
   completetime: 3
   materials:
-    Steel: 10000
-    Plasteel: 5000
-    Plastitanium: 4000
+    Steel: 8000
+    Plasteel: 1000
+    Plastitanium: 1000
     Plastic: 3000
     Gold: 2000
     Silver: 2000
-    Bluespace: 200
+    Bluespace: 100
     Diamond: 100
 
 - type: latheRecipe
@@ -21,12 +21,12 @@
   result: BorgIFFTSF
   completetime: 3
   materials:
-    Steel: 10000
-    Plasteel: 5000
-    Plastitanium: 4000
+    Steel: 8000
+    Plasteel: 1000
+    Plastitanium: 1000
     Plastic: 3000
     Gold: 2000
     Silver: 2000
-    Bluespace: 200
+    Bluespace: 100
     Diamond: 100
 # Exodus-end


### PR DESCRIPTION
## Описание PR
Уменьшил стоимость крафта фракционных боргов с абсурдной цены до приемлемой.
Теперь:
80 стали
10 пластали
10 пластитана
30 пластика
20 золота
20 серебра
1 бс кристалл
1 алмаз

## Почему / Баланс
По просьбам игроков, цена была абсурдной.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->



**Список изменений**
:cl:
- tweak: Изменена цена производства фракционных боргов и борга-охранника в сторону удешевления.

