### PR TITLE
Plastitanium in ore refinery

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/ore.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/ore.yml
@@ -38,5 +38,6 @@
   id: AdvancedSmelting
   recipes:
   - SheetPlasteel1
+  - SmeltPlastitanium # Exodus plastitanium smelting
   - SheetUGlass1
   - SheetRUGlass1

--- a/Resources/Prototypes/_Exodus/Recipes/Lathes/plastitanium.yml
+++ b/Resources/Prototypes/_Exodus/Recipes/Lathes/plastitanium.yml
@@ -1,0 +1,15 @@
+- type: latheRecipe
+  id: SmeltPlastitanium
+  result: SheetPlastitanium1
+  completetime: 0.06
+  materials:
+    Coal: 100
+    RawIron: 500
+    RawPlasma: 200
+
+- type: latheRecipe
+  id: ScrapSheetPlastitanium1
+  result: SheetPlastitanium1
+  parent: BaseMaterialsYesDiscountRecipe
+  materials:
+    RawScrap: 1000

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -130,7 +130,7 @@
   unit: materials-unit-sheet
   icon: { sprite: /Textures/_Mono/Objects/Materials/plastitanium.rsi, state: plastitanium }
   color: "#5c5c5c"
-  price: 6 # 600/sheet
+  price: 3 # Exodus plastitanium price rebalance, 300/sheet
   properties: # FH edit
     electrical: 3
     thermal: 5

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/scrap.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/scrap.yml
@@ -2,6 +2,7 @@
   id: NFScrapStatic
   recipes:
   - SmeltScrap
+  - ScrapSheetPlastitanium1 # Exodus plastitanium recycling
   - ScrapShipRepairDeviceAmmo
   - ScrapPartRodMetal1
   - ScrapSheetSteel1


### PR DESCRIPTION
## Описание PR
Пластитан теперь можно получить.
В продвинутой печке:
1 кусок руды угля
5 кусков руды железа
2 куска руды плазмы

Или за скрап.
10 скрапа = 1 пластитан.

Стоимость пластитана уменьшена вдвое.

## Почему / Баланс
По запросам игроков, облегчаем фарм фракциям и получения контента.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

:cl:
- add: Добавлен крафт пластитана в продвинутую печку, а так же в переработчих лома.
- tweak: Стоимость при продаже пластитана уменьшена вдвое.