### PR TITLE
NPC AI cores stop inertion

### DIFF
--- a/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
@@ -48,6 +48,11 @@ public sealed partial class ShipSteeringSystem : EntitySystem
     // collision evasion input consideration sectors: 24 outer, 12 inner, 1 zero-input
     private List<EvadeCandidate> _sectors = new();
 
+    // Exodus-begin stop NPC ships when their target is lost
+    private const float StopMaxLinearVelocity = 0.1f;
+    private const float StopMaxAngularVelocity = 0.01f;
+    // Exodus-end
+
     public override void Initialize()
     {
         base.Initialize();
@@ -65,7 +70,6 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         var targetUid = target.EntityId;
 
         if (shipUid == null
-            || TerminatingOrDeleted(targetUid)
             || !_shuttleQuery.TryComp(shipUid, out var shuttle)
             || !_physQuery.TryComp(shipUid, out var shipBody)
             || !_gridQuery.TryComp(shipUid, out var shipGrid))
@@ -73,6 +77,29 @@ public sealed partial class ShipSteeringSystem : EntitySystem
             ent.Comp.Status = ShipSteeringStatus.InRange;
             return;
         }
+
+        // Exodus-begin stop NPC ships when their target is lost
+        if (TerminatingOrDeleted(targetUid))
+        {
+            if (shipBody.LinearVelocity.LengthSquared() > StopMaxLinearVelocity * StopMaxLinearVelocity ||
+                MathF.Abs(shipBody.AngularVelocity) > StopMaxAngularVelocity)
+            {
+                ent.Comp.Status = ShipSteeringStatus.Moving;
+                args.GotInput = true;
+                args.Input = new ShuttleInput(Vector2.Zero, 0f, 1f);
+                _shuttle.SetInertiaDampening(shipUid.Value, shipBody, shuttle, Transform(shipUid.Value), InertiaDampeningMode.Anchor);
+                return;
+            }
+
+            _physics.SetLinearVelocity(shipUid.Value, Vector2.Zero, body: shipBody);
+            _physics.SetAngularVelocity(shipUid.Value, 0f, body: shipBody);
+            _shuttle.SetInertiaDampening(shipUid.Value, shipBody, shuttle, Transform(shipUid.Value), InertiaDampeningMode.Off);
+            ent.Comp.Status = ShipSteeringStatus.InRange;
+            RemCompDeferred<ShipSteererComponent>(ent);
+            return;
+        }
+        // Exodus-end
+
         ent.Comp.Status = ShipSteeringStatus.Moving;
 
         var shipXform = Transform(shipUid.Value);
@@ -726,7 +753,18 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, false))
             return;
 
-        RemComp<ShipSteererComponent>(ent);
+        // Exodus-begin stop NPC ships instead of leaving them drifting
+        if (!TryComp(ent, out TransformComponent? xform) ||
+            xform.GridUid is not { } grid ||
+            !_shuttleQuery.TryComp(grid, out _))
+        {
+            RemComp<ShipSteererComponent>(ent);
+            return;
+        }
+
+        ent.Comp.Coordinates = EntityCoordinates.Invalid;
+        ent.Comp.Status = ShipSteeringStatus.Moving;
+        // Exodus-end
     }
 
     private ref struct SteeringContext


### PR DESCRIPTION
## Описание PR
НПС-Ядра дронов перестают двигаться по иннерции если потеряли цель.

Проблема: Игроки брали на себя толпу ИИшек, делали БСС прыжок. Эта толпа потеряла цель, но по иннерции летит к примеру на Фалкон или Госпитали или Колосс.

## Почему / Баланс
Теперь чтобы ИИшка залетела в зону Колосса или Госпиталя нужно намеренно её привести. Больше никаких залетных ИИшек.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- tweak: Ядра ИИшек перестают лететь по инерции если потеряли цель. Больше никаких ненамеренных "залетных" квейков на Госпиталь.
