### PR TITLE
Ai Control Expansion

### DIFF
--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -151,8 +151,13 @@ public sealed partial class AiRemoteControlSystem : SharedAiRemoteControlSystem
         if (!TryComp<AiRemoteControllerComponent>(entity, out var aiRemoteComp))
             return;
 
-        if (!_map.TryFindGridAt(Transform(ai).MapPosition, out var grid, out var _) || Transform(entity).GridUid != grid)
-            return; // Mono no controlling borgs outside the ai's grid.
+        // Exodus-begin remote-ai-reconnection
+        var isOnAiGrid = _map.TryFindGridAt(Transform(ai).MapPosition, out var grid, out var _) &&
+                         Transform(entity).GridUid == grid;
+
+        if (!isOnAiGrid && aiRemoteComp.LastControllerMind != mindId)
+            return;
+        // Exodus-end
 
         // Exodus-begin ai-remote-power-check
         if (!HasRemotePower(entity, out var failMessage))
@@ -181,6 +186,7 @@ public sealed partial class AiRemoteControlSystem : SharedAiRemoteControlSystem
         _mind.ControlMob(ai, entity);
         aiRemoteComp.AiHolder = ai;
         aiRemoteComp.LinkedMind = mindId;
+        aiRemoteComp.LastControllerMind = mindId; // Exodus remote-ai-reconnection
 
         stationAiHeldComp.CurrentConnectedEntity = entity;
 
@@ -196,6 +202,12 @@ public sealed partial class AiRemoteControlSystem : SharedAiRemoteControlSystem
     {
         if (args.Handled || !TryComp<ActorComponent>(args.Performer, out var actor))
             return;
+
+        // Exodus-begin remote-ai-reconnection
+        if (!_mind.TryGetMind(uid, out var mindId, out _))
+            return;
+        // Exodus-end
+
         args.Handled = true;
 
         _userInterface.TryToggleUi(uid, RemoteDeviceUiKey.Key, actor.PlayerSession);
@@ -206,8 +218,11 @@ public sealed partial class AiRemoteControlSystem : SharedAiRemoteControlSystem
 
         while (query.MoveNext(out var queryUid, out var comp))
         {
-            if (Transform(queryUid).GridUid != aiGrid)
+            // Exodus-begin remote-ai-reconnection
+            if (Transform(queryUid).GridUid != aiGrid && comp.LastControllerMind != mindId)
                 continue;
+            // Exodus-end
+
             var data = new RemoteDevicesData
             {
                 NetEntityUid = GetNetEntity(queryUid),

--- a/Content.Shared/_CorvaxNext/Silicons/Borgs/Components/SharedAiRemoteControllerComponent.cs
+++ b/Content.Shared/_CorvaxNext/Silicons/Borgs/Components/SharedAiRemoteControllerComponent.cs
@@ -14,6 +14,7 @@ public sealed partial class AiRemoteControllerComponent : Component
 {
     [DataField] public EntityUid? AiHolder;
     [DataField] public EntityUid? LinkedMind;
+    [DataField] public EntityUid? LastControllerMind; // Exodus remote-ai-reconnection
 
     [DataField] public string[]? PreviouslyTransmitterChannels;
     [DataField] public string[]? PreviouslyActiveRadioChannels;


### PR DESCRIPTION
## Описание PR
Расширение логики ИИ.

Проблема:
ИИ покидает управление борга вне своего шатла. Вселиться обратно не может. Хотя ранее им управлял.

Теперь борг с AI Control модулем запоминает последнего mind ИИ который вселялся.
Если ИИ перестает управлять боргом, то он все равно может вселиться вне зависимости от расстояния в своего борга.

Управление другим ИИ - перезапишет последний mind ИИ.  

## Почему / Баланс
Расширение логики ИИ, усиление ИИ.
Теперь ИИ достаточно сильная единица для контроля в фракцией.
Плюс гигантский QoL ИИ мейнеров всех мастей, и фракционников и обычных.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- tweak: Расширена система контроля ИИ над боргами. Теперь борги под контролем ИИ запоминают последнего ИИ что управлял ими, позволяя вселяться в борга, даже если он находится не на гриде с ядром ИИ.
