### PR TITLE
USSP faction Del from spawn

### DIFF
--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
@@ -2,6 +2,7 @@
   id: USSPCommissar
   name: job-name-ussp-commissar
   description: job-description-ussp-commissar
+  setPreference: false # Exodus disable-ussp-faction
   playTimeTracker: JobUSSPCommissar
   requirements:
   # - !type:DepartmentTimeRequirement # Disabled until newgens get hours in

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
@@ -2,6 +2,7 @@
   id: USSPRifleman
   name: job-name-ussp-rifleman
   description: job-description-ussp-rifleman
+  setPreference: false # Exodus disable-ussp-faction
   playTimeTracker: JobUSSPRifleman
   requirements:
   - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
@@ -2,6 +2,7 @@
   id: USSPSergeant
   name: job-name-ussp-sergeant
   description: job-description-ussp-sergeant
+  setPreference: false # Exodus disable-ussp-faction
   playTimeTracker: JobUSSPSergeant
   requirements:
   # - !type:DepartmentTimeRequirement # Disabled until newgens get hours in

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
@@ -31,7 +31,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-            USSPSergeant: [ 0, 0 ]
-            USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #     USSPSergeant: [ 0, 0 ]
+        #     USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/buran.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/buran.yml
@@ -36,8 +36,10 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end
 

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
@@ -32,7 +32,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
@@ -32,7 +32,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
@@ -39,7 +39,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
@@ -31,7 +31,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
@@ -32,7 +32,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -33,8 +33,10 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end
 #Idfk what im doing I will not lie at all. What am I doing? Hello? Mooooooooooooom? AAAAAAAAAAAAAAAAA! *crashes your entire game and dies*

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
@@ -32,7 +32,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
@@ -34,7 +34,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/svinya.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/svinya.yml
@@ -37,7 +37,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
@@ -33,7 +33,9 @@
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-           USSPSergeant: [ 0, 0 ]
-           USSPRifleman: [ 0, 0 ]
+        # Exodus-begin disable-ussp-faction
+        # - type: StationJobs
+        #   availableJobs:
+        #    USSPSergeant: [ 0, 0 ]
+        #    USSPRifleman: [ 0, 0 ]
+        # Exodus-end


### PR DESCRIPTION
## Описание PR
Окончательное удаление СССП как фракции.

При апстриме проглядел касательно кораблей, что там можно выставить СССПшников.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- fix: Убран спавн СССП-фракционных ролей на кораблях СССП. Теперь невозможно зареспауниться за несуществующую роль.