### PR TITLE
Server anchorable unanchorable

### DIFF
--- a/Resources/Prototypes/_Exodus/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -17,8 +17,10 @@
     idleLoad: 60
     batteryRechargeRate: 3000
     batteryRechargeEfficiency: 0.95
+  - type: DisableToolUse
+    anchoring: false
   - type: Anchorable
-    flags: Anchorable
+    flags: Anchorable, Unanchorable
   - type: ShipRepairable
     repairTime: 30
     repairCost: 115

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -128,8 +128,10 @@
     idleLoad: 50
     batteryRechargeRate: 2400
     batteryRechargeEfficiency: 0.95
-  - type: Anchorable # Sorry Tunguska, but I am NOT risking this being used for a missile bus. - "what could go wrong" says redrover -- It turns out, a lot could and did.
-    flags: Anchorable
+  - type: DisableToolUse # Exodus gunnery-server-unanchorable
+    anchoring: false
+  - type: Anchorable # Exodus gunnery-server-unanchorable
+    flags: Anchorable, Unanchorable
   - type: ShipRepairable
     repairTime: 25
     repairCost: 100


### PR DESCRIPTION
## Описание PR
Вернул скрутку сервера на 90.
Добавил скрутку сервера на 120.

## Почему / Баланс
Сервер на 90 апстрим убрал скрутку, возвращаем.
А сервер на 120 нигде толком сейчас не используется, однако будет одной из самой желаемой целью для манча. Минусов не вижу.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->


**Список изменений**
:cl:
- tweak: Добавлена скрутка орудийного сервера на 120.
- fix: Возвращена скрутка орудийного сервера на 90.
