### PR TITLE
Charon less recoil

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
@@ -21,7 +21,7 @@
   - type: GunSignalControl
   - type: Gun
     fireRate: 0.05
-    recoil: 2500 # 100x
+    recoil: 250 # Exodus Charon recoil
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 700 # projectiles cannot go faster than this


### PR DESCRIPTION
## Описание PR
Уменьшение отдачи Харона в 10 раз до играбельного состояния.

## Почему / Баланс
Харон в обычной вариации очень сильно откидывает шатл в сторону, что превращает геймплей на нём в боль.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->


**Список изменений**
:cl:
- tweak: Отдача Харона уменьшена в 10 раз.