### PR TITLE
Fix autopilot stopping hotfixes

### DIFF
--- a/Content.Server/_Mono/NPC/HTN/ShipSteererComponent.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteererComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared._NF.Shuttles.Events; // Exodus - restore pre-autopilot dampening
 using Robust.Shared.Map;
 using System.Numerics;
 
@@ -9,6 +10,11 @@ namespace Content.Server._Mono.NPC.HTN;
 [RegisterComponent]
 public sealed partial class ShipSteererComponent : Component
 {
+    // Exodus-begin restore the player-selected dampening mode when autopilot releases the ship
+    [ViewVariables(VVAccess.ReadWrite)]
+    public InertiaDampeningMode? PreviousDampeningMode;
+    // Exodus-end
+
     [ViewVariables(VVAccess.ReadWrite)]
     public ShipSteeringStatus Status = ShipSteeringStatus.Moving;
 

--- a/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
@@ -682,6 +682,11 @@ public sealed partial class ShipSteeringSystem : EntitySystem
     {
         var args = outerArgs.Args;
         var targetEnt = ent.Comp.Coordinates.EntityId;
+
+        // Exodus - the target can disappear while the ship is performing an emergency stop.
+        if (TerminatingOrDeleted(targetEnt))
+            return;
+
         var targetGrid = Transform(targetEnt).GridUid;
 
         // if we want to finish movement on collide with target, do so
@@ -740,6 +745,8 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, false))
             ent.Comp = AddComp<ShipSteererComponent>(ent);
 
+        // Exodus - preserve the pilot-selected dampening mode while autopilot manages its own braking.
+        ent.Comp.PreviousDampeningMode ??= _shuttle.NfGetInertiaDampeningMode(ent.Owner);
         ent.Comp.Coordinates = coordinates;
 
         return ent.Comp;
@@ -753,17 +760,17 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, false))
             return;
 
-        // Exodus-begin stop NPC ships instead of leaving them drifting
-        if (!TryComp(ent, out TransformComponent? xform) ||
-            xform.GridUid is not { } grid ||
-            !_shuttleQuery.TryComp(grid, out _))
+        // Exodus-begin immediately release the ship when its autopilot is disabled
+        var xform = Transform(ent);
+        if (xform.GridUid is { } grid &&
+            ent.Comp.PreviousDampeningMode is { } dampeningMode &&
+            _shuttleQuery.TryComp(grid, out var shuttle) &&
+            _physQuery.TryComp(grid, out var body))
         {
-            RemComp<ShipSteererComponent>(ent);
-            return;
+            _shuttle.SetInertiaDampening(grid, body, shuttle, Transform(grid), dampeningMode);
         }
 
-        ent.Comp.Coordinates = EntityCoordinates.Invalid;
-        ent.Comp.Status = ShipSteeringStatus.Moving;
+        RemComp<ShipSteererComponent>(ent);
         // Exodus-end
     }
 


### PR DESCRIPTION
## Описание PR
Из-за изменения логики остановки ИИ когда он потерял цель, я случайно частично сломал автопилот.
Автопилот при отмене, теперь принудительно останавливает грид плавно, хотя раньше просто возвращал контроль.

Исправляем. Теперь автопилот работает как раньше.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->



**Список изменений**
:cl:
- fix: Исправлено некорректное поведение автопилота при отключении. Теперь он вновь полностью отдает контроль над судном, а не принудительно останавливает.
