### PR TITLE
Round 8 hours

### DIFF
--- a/Resources/Prototypes/_Exodus/GameRules/timings.yml
+++ b/Resources/Prototypes/_Exodus/GameRules/timings.yml
@@ -8,8 +8,8 @@
       max: 7200
 
 - type: entity
-  id: RoundEndRuleHour6
+  id: RoundEndRuleHour8
   parent: BaseGameRule
   components:
   - type: RoundEndTimeRule
-    endAt: 21600 # 6 hour
+    endAt: 26820 # 7 hours 27 minutes; 25 minute shuttle countdown

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -18,7 +18,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoRogueTSF
@@ -35,7 +35,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoRogueUSSP
@@ -52,7 +52,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoTSFUSSP
@@ -69,7 +69,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoADS
@@ -87,7 +87,7 @@
   # Exodus: ADS and Asakim shuttle event schedulers replaced by manual emergency beacons.
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoChimera
@@ -105,7 +105,7 @@
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoMixed
@@ -128,7 +128,7 @@
   - ExodusSyndicateScheduler # Exodus-syndicate-ships
   - MonoMonolithicEventsScheduler
   # - PortstrikeAnnounceRuleHour2 # Exodus-NoPortstrikeAnnounce
-  - RoundEndRuleHour6 # Exodus
+  - RoundEndRuleHour8 # Exodus
 
 - type: gamePreset
   id: MonoAllAtOnce


### PR DESCRIPTION
## Описание PR
Раунды теперь длятся 7 часов 52 минуты.
Шатл начинается в 7 часов 27 минут.
8 минут не хватает чтобы ровно до 8 часов, чтобы не сбивать график серверов т.к. 2 минуты после раунда + 6 минут без таймера сидим в лобби.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->


**Список изменений**
:cl:
- tweak: Раунд длится теперь 7 часов 52 минут, погрешность 8 минут на лобби + время после раунда, чтобы не сбивать график.
