### PR TITLE
Leviathan deletion and explosion fix

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -212,7 +212,8 @@ public sealed partial class ExplosionSystem
         float? fireStacks,
         float? temperature,
         float currentIntensity,
-        EntityUid? cause)
+        EntityUid? cause,
+        ref Dictionary<EntityUid, DamageSpecifier>? groupedDamage) // Exodus: damage groups are scoped to one explosion
     {
         var size = grid.Comp.TileSize;
         var gridBox = new Box2(tile * size, (tile + 1) * size);
@@ -231,7 +232,7 @@ public sealed partial class ExplosionSystem
         // process those entities
         foreach (var (uid, xform) in list)
         {
-            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause, ref groupedDamage); // Exodus: grouped damage
         }
 
         // process anchored entities
@@ -249,7 +250,7 @@ public sealed partial class ExplosionSystem
                 continue;
             }
             // Exodus-End
-            ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause);
+            ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause, ref groupedDamage); // Exodus: grouped damage
         }
 
         // heat the atmosphere
@@ -276,7 +277,7 @@ public sealed partial class ExplosionSystem
         if (!tileBlocked)
         {
             foreach (var entity in _subFloorDeferred)
-                ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause);
+                ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause, ref groupedDamage); // Exodus: grouped damage
         }
         // Exodus-End
 
@@ -299,7 +300,7 @@ public sealed partial class ExplosionSystem
         {
             // Here we only throw, no dealing damage. Containers n such might drop their entities after being destroyed, but
             // they should handle their own damage pass-through, with their own damage reduction calculation.
-            ProcessEntity(uid, epicenter, null, throwForce, id, xform, null, cause);
+            ProcessEntity(uid, epicenter, null, throwForce, id, xform, null, cause, ref groupedDamage); // Exodus: grouped damage
         }
 
         return !tileBlocked;
@@ -336,7 +337,8 @@ public sealed partial class ExplosionSystem
         HashSet<EntityUid> processed,
         string id,
         float? fireStacks,
-        EntityUid? cause)
+        EntityUid? cause,
+        ref Dictionary<EntityUid, DamageSpecifier>? groupedDamage) // Exodus: damage groups are scoped to one explosion
     {
         var gridBox = Box2.FromDimensions(tile * DefaultTileSize, new Vector2(DefaultTileSize, DefaultTileSize));
         var worldBox = spaceMatrix.TransformBox(gridBox);
@@ -352,7 +354,7 @@ public sealed partial class ExplosionSystem
         foreach (var (uid, xform) in state.Item1)
         {
             processed.Add(uid);
-            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause, ref groupedDamage); // Exodus: grouped damage
         }
 
         if (throwForce <= 0)
@@ -366,7 +368,7 @@ public sealed partial class ExplosionSystem
 
         foreach (var (uid, xform) in list)
         {
-            ProcessEntity(uid, epicenter, null, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, null, throwForce, id, xform, fireStacks, cause, ref groupedDamage); // Exodus: grouped damage
         }
     }
 
@@ -454,6 +456,14 @@ public sealed partial class ExplosionSystem
         }
     }
 
+    // Exodus-begin: applies damage deferred by an explosion damage group.
+    internal void ApplyGroupedExplosionDamage(EntityUid entity, DamageSpecifier damage)
+    {
+        _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, ignoreGlobalModifiers: true,
+            originFlag: DamageableSystem.DamageOriginFlag.Explosion);
+    }
+    // Exodus-end
+
     /// <summary>
     ///     This function actually applies the explosion affects to an entity.
     /// </summary>
@@ -465,13 +475,30 @@ public sealed partial class ExplosionSystem
         string id,
         TransformComponent? xform,
         float? fireStacksOnIgnite,
-        EntityUid? cause)
+        EntityUid? cause,
+        ref Dictionary<EntityUid, DamageSpecifier>? groupedDamage)
     {
         if (originalDamage != null)
         {
             GetEntitiesToDamage(uid, originalDamage, id);
             foreach (var (entity, damage) in _toDamage)
             {
+                // Exodus-begin: tail segments forward only their largest hit from this explosion.
+                if (_tailedSegmentQuery.TryGetComponent(entity, out var segment) &&
+                    segment.HeadEntity != EntityUid.Invalid &&
+                    _tailedQuery.TryGetComponent(segment.HeadEntity, out var tail) &&
+                    tail.AggregateSegmentExplosionDamage &&
+                    !TerminatingOrDeleted(segment.HeadEntity) &&
+                    !EntityManager.IsQueuedForDeletion(segment.HeadEntity))
+                {
+                    groupedDamage ??= new Dictionary<EntityUid, DamageSpecifier>();
+                    if (!groupedDamage.TryGetValue(segment.HeadEntity, out var existingDamage) || damage.GetTotal() > existingDamage.GetTotal())
+                        groupedDamage[segment.HeadEntity] = damage;
+
+                    continue;
+                }
+                // Exodus-end
+
                 if (_actorQuery.HasComp(entity))
                 {
                     // Log damage to player entities only, cause this will create a massive amount of log spam otherwise.
@@ -674,6 +701,10 @@ sealed class Explosion
     ///     the explosion trigger chunk regeneration & shuttle-system processing every tick.
     /// </summary>
     private readonly Dictionary<Entity<MapGridComponent>, List<(Vector2i, Tile)>> _tileUpdateDict = new();
+
+    // Exodus: redirected damage is accumulated separately for each Explosion instance.
+    private Dictionary<EntityUid, DamageSpecifier>? _groupedDamage;
+    private bool _groupedDamageApplied;
 
     // Entity Queries
     private readonly EntityQuery<TransformComponent> _xformQuery;
@@ -903,7 +934,8 @@ sealed class Explosion
                     ExplosionType.FireStacks,
                     ExplosionType.Temperature,
                     _currentIntensity,
-                    Cause);
+                    Cause,
+                    ref _groupedDamage); // Exodus: grouped damage
 
                 // If the floor is not blocked by some dense object, damage the floor tiles.
                 if (canDamageFloor)
@@ -922,7 +954,8 @@ sealed class Explosion
                     ProcessedEntities,
                     ExplosionType.ID,
                     ExplosionType.FireStacks,
-                    Cause);
+                    Cause,
+                    ref _groupedDamage); // Exodus: grouped damage
             }
 
             if (!MoveNext())
@@ -931,8 +964,31 @@ sealed class Explosion
 
         // Update damaged/broken tiles on the grid.
         SetTiles();
+
+        // Exodus: apply one maximum redirected hit per target after this source has finished processing.
+        if (FinishedProcessing && !_groupedDamageApplied)
+        {
+            ApplyGroupedDamage();
+            _groupedDamageApplied = true;
+        }
+
         return processed;
     }
+
+    // Exodus-begin: group members do not multiply forwarded explosion damage.
+    private void ApplyGroupedDamage()
+    {
+        if (_groupedDamage is not { Count: > 0 } groupedDamage)
+            return;
+
+        foreach (var (entity, damage) in groupedDamage)
+        {
+            _system.ApplyGroupedExplosionDamage(entity, damage);
+        }
+
+        groupedDamage.Clear();
+    }
+    // Exodus-end
 
     private void SetTiles()
     {

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Database;
 using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Explosion.EntitySystems;
+using Content.Shared._Exodus.Tailed; // Exodus: aggregate explosion damage from linked tail segments
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
 using Content.Shared.Projectiles;
@@ -78,6 +79,8 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     private EntityQuery<DamageableComponent> _damageableQuery;
     private EntityQuery<AirtightComponent> _airtightQuery;
     private EntityQuery<SubFloorHideComponent> _subFloorQuery; // Exodus
+    private EntityQuery<TailedEntityComponent> _tailedQuery; // Exodus
+    private EntityQuery<TailedEntitySegmentComponent> _tailedSegmentQuery; // Exodus
 
     /// <summary>
     ///     "Tile-size" for space when there are no nearby grids to use as a reference.
@@ -135,6 +138,8 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         _damageableQuery = GetEntityQuery<DamageableComponent>();
         _airtightQuery = GetEntityQuery<AirtightComponent>();
         _subFloorQuery = GetEntityQuery<SubFloorHideComponent>(); // Exodus
+        _tailedQuery = GetEntityQuery<TailedEntityComponent>(); // Exodus
+        _tailedSegmentQuery = GetEntityQuery<TailedEntitySegmentComponent>(); // Exodus
 
         _prototypeManager.PrototypesReloaded += ReloadExplosionPrototypes;
     }

--- a/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
+++ b/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
@@ -32,6 +32,11 @@ public sealed partial class WorldControllerSystem : EntitySystem
     private Dictionary<EntityUid, Dictionary<Vector2i, List<EntityUid>>> _chunksToLoad = new();
     // </Mono>
 
+    // Exodus-begin: worldgen-loader-exempt
+    private EntityQuery<LoadedChunkComponent> _loadedChunkQuery;
+    private EntityQuery<WorldControllerComponent> _worldControllerQuery;
+    // Exodus-end: worldgen-loader-exempt
+
     private ISawmill _sawmill = default!;
 
     /// <inheritdoc />
@@ -41,6 +46,11 @@ public sealed partial class WorldControllerSystem : EntitySystem
         SubscribeLocalEvent<LoadedChunkComponent, ComponentStartup>(OnChunkLoadedCore);
         SubscribeLocalEvent<LoadedChunkComponent, ComponentShutdown>(OnChunkUnloadedCore);
         SubscribeLocalEvent<WorldChunkComponent, ComponentShutdown>(OnChunkShutdown);
+
+        // Exodus-begin: worldgen-loader-exempt
+        _loadedChunkQuery = GetEntityQuery<LoadedChunkComponent>();
+        _worldControllerQuery = GetEntityQuery<WorldControllerComponent>();
+        // Exodus-end: worldgen-loader-exempt
     }
 
     /// <summary>
@@ -137,8 +147,15 @@ public sealed partial class WorldControllerSystem : EntitySystem
             if (ghostQuery.HasComponent(uid))
                 continue;
 
-            if (worldChunkLoadingExemptQuery.HasComponent(uid)) // Exodus worldgen-loader-exempt
+            // Exodus-begin: worldgen-loader-exempt
+            if (worldChunkLoadingExemptQuery.TryComp(uid, out var loadingExempt))
+            {
+                if (loadingExempt.RetainLoadedChunks)
+                    TryRetainLoadedChunks(uid, xform, PlayerLoadRadius);
+
                 continue;
+            }
+            // Exodus-end: worldgen-loader-exempt
 
             // Mono edit
             TryAddChunkLoader(uid, xform, PlayerLoadRadius);
@@ -297,6 +314,50 @@ public sealed partial class WorldControllerSystem : EntitySystem
 
         return true;
     }
+
+    // Exodus-begin: worldgen-loader-exempt
+    /// <summary>
+    /// Adds already loaded chunks around an entity to the unload protection set without creating new chunks.
+    /// </summary>
+    private bool TryRetainLoadedChunks(
+        EntityUid uid,
+        TransformComponent xform,
+        int radius)
+    {
+        if (xform.MapUid is not { } map ||
+            !_chunksToLoad.TryGetValue(map, out var chunksToLoad) ||
+            !_worldControllerQuery.TryComp(map, out var controller))
+        {
+            return false;
+        }
+
+        var worldPosition = _xformSys.GetWorldPosition(xform);
+        var mapVelocity = _physics.GetMapLinearVelocity(uid, xform: xform);
+        worldPosition += mapVelocity * _updateInterval;
+
+        var chunkCoords = WorldGen.WorldToChunkCoords(worldPosition);
+        var chunks = new GridPointsNearEnumerator(chunkCoords.Floored(), radius);
+
+        while (chunks.MoveNext(out var chunk))
+        {
+            if (!controller.Chunks.TryGetValue(chunk.Value, out var chunkEntity) ||
+                !_loadedChunkQuery.HasComp(chunkEntity))
+            {
+                continue;
+            }
+
+            if (!chunksToLoad.TryGetValue(chunk.Value, out var loaders))
+            {
+                loaders = new List<EntityUid>(1);
+                chunksToLoad[chunk.Value] = loaders;
+            }
+
+            loaders.Add(uid);
+        }
+
+        return true;
+    }
+    // Exodus-end: worldgen-loader-exempt
 }
 
 /// <summary>

--- a/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
+++ b/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
@@ -1,7 +1,14 @@
 namespace Content.Server._Exodus.Worldgen.Components;
 
 /// <summary>
-/// Prevents a player-controlled entity from loading worldgen chunks around itself.
+/// Prevents a player-controlled entity from loading new worldgen chunks around itself.
 /// </summary>
 [RegisterComponent]
-public sealed partial class WorldChunkLoadingExemptComponent : Component;
+public sealed partial class WorldChunkLoadingExemptComponent : Component
+{
+    /// <summary>
+    /// Keeps already loaded worldgen chunks nearby from unloading without loading new chunks.
+    /// </summary>
+    [DataField]
+    public bool RetainLoadedChunks;
+}

--- a/Content.Shared/_Exodus/Tailed/TailedEntityComponent.cs
+++ b/Content.Shared/_Exodus/Tailed/TailedEntityComponent.cs
@@ -13,6 +13,12 @@ namespace Content.Shared._Exodus.Tailed;
 public sealed partial class TailedEntityComponent : Component
 {
     /// <summary>
+    ///     Whether explosion damage dealt to tail segments is applied to the head once per explosion.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool AggregateSegmentExplosionDamage;
+
+    /// <summary>
     /// amount of entities in between the tail and the head
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
@@ -49,6 +49,7 @@
       settings: default
   - type: GhostTakeoverAvailable
   - type: WorldChunkLoadingExempt
+    retainLoadedChunks: true
   - type: CleanupImmune
   - type: PointLight
     color: "#FF8227FF"

--- a/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
@@ -56,6 +56,7 @@
     radius: 3
     energy: 3
   - type: TailedEntity
+    aggregateSegmentExplosionDamage: true
     amount: 65
     spacing: 1
     prototype: SpaceWhaleSegment

--- a/Resources/Prototypes/_Exodus/explosion.yml
+++ b/Resources/Prototypes/_Exodus/explosion.yml
@@ -12,7 +12,6 @@
   tileBreakIntensity: [0, 8, 20]
   tileBreakRerollReduction: 10
   intensityPerState: 20
-  maxCombineDistance: 0 # Exodus: each destroyed ship gun remains a separate explosion source
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 6

--- a/Resources/Prototypes/_Exodus/explosion.yml
+++ b/Resources/Prototypes/_Exodus/explosion.yml
@@ -12,6 +12,7 @@
   tileBreakIntensity: [0, 8, 20]
   tileBreakRerollReduction: 10
   intensityPerState: 20
+  maxCombineDistance: 0 # Exodus: each destroyed ship gun remains a separate explosion source
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 6


### PR DESCRIPTION
## Описание PR
1. Расширил систему генерации карт. Теперь для левиафана стоит метка, которая запрещает удалять прогруженные чанки рядом. Сам он их дополнительно не прогружает. Баг: Левиафан стоит на астероиде, который заспавнил игрок. Астероид деспавнится, левиафан тоже.
2. Расширил систему взрывов. Теперь для всех последующих существ с хвостом - взрыв работает только на одну сущность хвоста, а не как раньше. Баг: Взрыв наносит 500 урона, но из-за того что у Левиафана много сегментов и каждый передает урон в голову, эти 500 урона складываются до условных 5000.

## Почему / Баланс
Багфиксы


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->


**Список изменений**
:cl:
- fix: Пофикшен баг при котором один взрыв, задевая несколько сегментов левиафана наносил огромное количество урона. Теперь один взрыв по нескольким сегментам наносит только разовый свой урон.
- fix: Исправлено удаление левиафана при очистке сектора от астероидов если левиафан был на нем. Теперь левиафан прогружает рядом астероиды. Как и раньше, не создает новых. 
