### PR TITLE
Leviathan Unload Fix

### DIFF
--- a/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
+++ b/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
@@ -151,7 +151,7 @@ public sealed partial class WorldControllerSystem : EntitySystem
             if (worldChunkLoadingExemptQuery.TryComp(uid, out var loadingExempt))
             {
                 if (loadingExempt.RetainLoadedChunks)
-                    TryRetainLoadedChunks(uid, xform, PlayerLoadRadius);
+                    TryRetainLoadedChunks(uid, xform, Math.Max(0, loadingExempt.RetainLoadedChunksRadius));
 
                 continue;
             }

--- a/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
+++ b/Content.Server/Worldgen/Systems/WorldControllerSystem.cs
@@ -3,6 +3,8 @@ using Content.Server._Exodus.Worldgen.Components; // Exodus worldgen-loader-exem
 using Content.Server._Mono.Worldgen.Components;
 using Content.Server.Power.Components;
 using Content.Server.Worldgen.Components;
+using Content.Server.Worldgen.Components.Debris; // Exodus: retain the chunk owning protected debris
+using Content.Shared._Exodus.Tailed; // Exodus: retain debris beneath protected tail segments
 using Content.Shared.Ghost;
 using Content.Shared.Mind.Components;
 using JetBrains.Annotations;
@@ -35,6 +37,10 @@ public sealed partial class WorldControllerSystem : EntitySystem
     // Exodus-begin: worldgen-loader-exempt
     private EntityQuery<LoadedChunkComponent> _loadedChunkQuery;
     private EntityQuery<WorldControllerComponent> _worldControllerQuery;
+    private EntityQuery<OwnedDebrisComponent> _ownedDebrisQuery;
+    private EntityQuery<TailedEntityComponent> _tailedEntityQuery;
+    private EntityQuery<TransformComponent> _transformQuery;
+    private EntityQuery<WorldChunkComponent> _worldChunkQuery;
     // Exodus-end: worldgen-loader-exempt
 
     private ISawmill _sawmill = default!;
@@ -50,6 +56,10 @@ public sealed partial class WorldControllerSystem : EntitySystem
         // Exodus-begin: worldgen-loader-exempt
         _loadedChunkQuery = GetEntityQuery<LoadedChunkComponent>();
         _worldControllerQuery = GetEntityQuery<WorldControllerComponent>();
+        _ownedDebrisQuery = GetEntityQuery<OwnedDebrisComponent>();
+        _tailedEntityQuery = GetEntityQuery<TailedEntityComponent>();
+        _transformQuery = GetEntityQuery<TransformComponent>();
+        _worldChunkQuery = GetEntityQuery<WorldChunkComponent>();
         // Exodus-end: worldgen-loader-exempt
     }
 
@@ -152,6 +162,15 @@ public sealed partial class WorldControllerSystem : EntitySystem
             {
                 if (loadingExempt.RetainLoadedChunks)
                     TryRetainLoadedChunks(uid, xform, Math.Max(0, loadingExempt.RetainLoadedChunksRadius));
+
+                if (loadingExempt.EnsureParentDebrisChunkLoaded)
+                    TryAddParentDebrisChunkLoader(uid, xform);
+
+                if (loadingExempt.EnsureTailDebrisChunksLoaded &&
+                    _tailedEntityQuery.TryComp(uid, out var tail))
+                {
+                    TryAddTailDebrisChunkLoaders((uid, tail));
+                }
 
                 continue;
             }
@@ -356,6 +375,49 @@ public sealed partial class WorldControllerSystem : EntitySystem
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Adds the existing worldgen chunk which owns the grid under an entity to the load set.
+    /// </summary>
+    private bool TryAddParentDebrisChunkLoader(EntityUid uid, TransformComponent xform)
+    {
+        if (xform.GridUid is not { } grid ||
+            !_ownedDebrisQuery.TryComp(grid, out var debris) ||
+            !_worldChunkQuery.TryComp(debris.OwningController, out var chunk) ||
+            !_chunksToLoad.TryGetValue(chunk.Map, out var chunksToLoad))
+        {
+            return false;
+        }
+
+        if (!chunksToLoad.TryGetValue(chunk.Coordinates, out var loaders))
+        {
+            loaders = new List<EntityUid>(1);
+            chunksToLoad[chunk.Coordinates] = loaders;
+        }
+
+        if (!loaders.Contains(uid))
+            loaders.Add(uid);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Adds the chunks owning grids beneath valid tail segments to the load set.
+    /// </summary>
+    private void TryAddTailDebrisChunkLoaders(Entity<TailedEntityComponent> head)
+    {
+        for (var i = 0; i < head.Comp.TailSegments.Count; i++)
+        {
+            var segment = head.Comp.TailSegments[i];
+
+            if (segment == EntityUid.Invalid ||
+                TerminatingOrDeleted(segment) ||
+                !_transformQuery.TryComp(segment, out var xform))
+                continue;
+
+            TryAddParentDebrisChunkLoader(head.Owner, xform);
+        }
     }
     // Exodus-end: worldgen-loader-exempt
 }

--- a/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
+++ b/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
@@ -11,4 +11,10 @@ public sealed partial class WorldChunkLoadingExemptComponent : Component
     /// </summary>
     [DataField]
     public bool RetainLoadedChunks;
+
+    /// <summary>
+    /// Radius in worldgen chunks within which loaded chunks are protected from unloading.
+    /// </summary>
+    [DataField]
+    public int RetainLoadedChunksRadius = 2;
 }

--- a/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
+++ b/Content.Server/_Exodus/Worldgen/Components/WorldChunkLoadingExemptComponent.cs
@@ -17,4 +17,16 @@ public sealed partial class WorldChunkLoadingExemptComponent : Component
     /// </summary>
     [DataField]
     public int RetainLoadedChunksRadius = 2;
+
+    /// <summary>
+    /// Ensures the worldgen chunk owning the grid underneath the entity is loaded.
+    /// </summary>
+    [DataField]
+    public bool EnsureParentDebrisChunkLoaded;
+
+    /// <summary>
+    /// Ensures chunks owning grids underneath tail segments are loaded.
+    /// </summary>
+    [DataField]
+    public bool EnsureTailDebrisChunksLoaded;
 }

--- a/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
@@ -50,6 +50,7 @@
   - type: GhostTakeoverAvailable
   - type: WorldChunkLoadingExempt
     retainLoadedChunks: true
+    retainLoadedChunksRadius: 5
   - type: CleanupImmune
   - type: PointLight
     color: "#FF8227FF"

--- a/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Mobs/NPCs/leviathan.yml
@@ -50,7 +50,9 @@
   - type: GhostTakeoverAvailable
   - type: WorldChunkLoadingExempt
     retainLoadedChunks: true
-    retainLoadedChunksRadius: 5
+    ensureParentDebrisChunkLoaded: true
+    ensureTailDebrisChunksLoaded: true
+    retainLoadedChunksRadius: 2
   - type: CleanupImmune
   - type: PointLight
     color: "#FF8227FF"


### PR DESCRIPTION
## Описание PR
Изменил логику защиты левиафана и его сегментов от удаления на непрогруженном дербисе. Ранее оно защищало только на прогруженном. Исправляюсь.
Теперь непрогруженный дербис прогружается от головы и хвоста.

Должно быть до 100 легких проверок в секунду для левиафана.

## Почему / Баланс
Багфикс


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
No fun т.к. это следствие из предыдущего фикса.
