### PR TITLE
Ipc speed do after nerf

### DIFF
--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -119,6 +119,10 @@ public sealed partial class DoAfterArgs
     [DataField]
     public bool BreakOnMove;
 
+    // Exodus do-after-movement-slowdown
+    [DataField]
+    public bool ApplyMovementSlowdown;
+
     /// <summary>
     ///     Whether to break on movement when the user is weightless.
     ///     This does nothing if <see cref="BreakOnMove"/> is false.
@@ -272,6 +276,7 @@ public sealed partial class DoAfterArgs
         BreakOnHandChange = other.BreakOnHandChange;
         BreakOnDropItem = other.BreakOnDropItem;
         BreakOnMove = other.BreakOnMove;
+        ApplyMovementSlowdown = other.ApplyMovementSlowdown; // Exodus do-after-movement-slowdown
         BreakOnWeightlessMove = other.BreakOnWeightlessMove;
         MovementThreshold = other.MovementThreshold;
         DistanceThreshold = other.DistanceThreshold;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -142,6 +142,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             doAfter.StartTime = GameTiming.CurTime;
             doAfter.Completed = false;
         }
+
+        RaiseDoAfterMovementSlowdownChanged(doAfter); // Exodus do-after-movement-slowdown
     }
 
     private bool ShouldCancel(DoAfter doAfter,

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -100,6 +100,17 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             tcs.SetResult(doAfter.Cancelled ? DoAfterStatus.Cancelled : DoAfterStatus.Finished);
     }
 
+    // Exodus-begin do-after-movement-slowdown
+    private void RaiseDoAfterMovementSlowdownChanged(DoAfter doAfter)
+    {
+        if (!doAfter.Args.ApplyMovementSlowdown || !Exists(doAfter.Args.User))
+            return;
+
+        var ev = new DoAfterMovementSlowdownChangedEvent();
+        RaiseLocalEvent(doAfter.Args.User, ref ev);
+    }
+    // Exodus-end
+
     private void OnDoAfterGetState(EntityUid uid, DoAfterComponent comp, ref ComponentGetState args)
     {
         args.State = new DoAfterComponentState(EntityManager, comp);
@@ -210,6 +221,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             args.BreakOnMove = interruptionBreak.BreakOnMove;
             args.BreakOnHandChange = interruptionBreak.BreakOnHandChange;
             args.BreakOnDropItem = interruptionBreak.BreakOnDropItem;
+            args.ApplyMovementSlowdown = interruptionBreak.ApplyMovementSlowdown; // Exodus do-after-movement-slowdown
         }
         // Exodus-end
 
@@ -281,6 +293,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         comp.DoAfters.Add(doAfter.Index, doAfter);
         EnsureComp<ActiveDoAfterComponent>(args.User);
         Dirty(args.User, comp);
+        RaiseDoAfterMovementSlowdownChanged(doAfter); // Exodus do-after-movement-slowdown
         args.Event.DoAfter = doAfter;
         return true;
     }
@@ -380,6 +393,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         // Caller is responsible for dirtying the component.
         doAfter.CancelledTime = GameTiming.CurTime;
         RaiseDoAfterEvents(doAfter, component);
+        RaiseDoAfterMovementSlowdownChanged(doAfter); // Exodus do-after-movement-slowdown
     }
     #endregion
 

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -216,7 +216,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             var interruptionBreak = new GetDoAfterInterruptionBreakEvent(
                 args.BreakOnMove,
                 args.BreakOnHandChange,
-                args.BreakOnDropItem);
+                args.BreakOnDropItem,
+                args.ApplyMovementSlowdown);
             RaiseLocalEvent(args.User, ref interruptionBreak);
             args.BreakOnMove = interruptionBreak.BreakOnMove;
             args.BreakOnHandChange = interruptionBreak.BreakOnHandChange;

--- a/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptComponent.cs
+++ b/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptComponent.cs
@@ -19,4 +19,10 @@ public sealed partial class DoAfterInterruptionExemptComponent : Component
 {
     [DataField]
     public DoAfterInterruptionExemptions Exemptions = DoAfterInterruptionExemptions.Movement;
+
+    [DataField]
+    public float WalkSpeedModifier = 0.5f;
+
+    [DataField]
+    public float SprintSpeedModifier = 0.5f;
 }

--- a/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptSystem.cs
+++ b/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptSystem.cs
@@ -1,18 +1,28 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Movement.Systems;
+
 namespace Content.Shared._Exodus.DoAfter;
 
 public sealed class DoAfterInterruptionExemptSystem : EntitySystem
 {
+    [Dependency] private MovementSpeedModifierSystem _movementSpeed = default!;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<DoAfterInterruptionExemptComponent, GetDoAfterInterruptionBreakEvent>(OnGetDoAfterInterruptionBreak);
+        SubscribeLocalEvent<DoAfterInterruptionExemptComponent, DoAfterMovementSlowdownChangedEvent>(OnDoAfterMovementSlowdownChanged);
+        SubscribeLocalEvent<DoAfterInterruptionExemptComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
     }
 
     private void OnGetDoAfterInterruptionBreak(Entity<DoAfterInterruptionExemptComponent> ent,
         ref GetDoAfterInterruptionBreakEvent args)
     {
-        if (ent.Comp.Exemptions.HasFlag(DoAfterInterruptionExemptions.Movement))
+        if (ent.Comp.Exemptions.HasFlag(DoAfterInterruptionExemptions.Movement) && args.BreakOnMove)
+        {
             args.BreakOnMove = false;
+            args.ApplyMovementSlowdown = true;
+        }
 
         if (ent.Comp.Exemptions.HasFlag(DoAfterInterruptionExemptions.HandChange))
             args.BreakOnHandChange = false;
@@ -20,10 +30,36 @@ public sealed class DoAfterInterruptionExemptSystem : EntitySystem
         if (ent.Comp.Exemptions.HasFlag(DoAfterInterruptionExemptions.DropItem))
             args.BreakOnDropItem = false;
     }
+
+    private void OnDoAfterMovementSlowdownChanged(Entity<DoAfterInterruptionExemptComponent> ent,
+        ref DoAfterMovementSlowdownChangedEvent args)
+    {
+        _movementSpeed.RefreshMovementSpeedModifiers(ent);
+    }
+
+    private void OnRefreshMovementSpeedModifiers(Entity<DoAfterInterruptionExemptComponent> ent,
+        ref RefreshMovementSpeedModifiersEvent args)
+    {
+        if (!TryComp<DoAfterComponent>(ent, out var doAfter))
+            return;
+
+        foreach (var active in doAfter.DoAfters.Values)
+        {
+            if (!active.Args.ApplyMovementSlowdown || active.Cancelled || active.Completed)
+                continue;
+
+            args.ModifySpeed(ent.Comp.WalkSpeedModifier, ent.Comp.SprintSpeedModifier);
+            return;
+        }
+    }
 }
 
 [ByRefEvent]
 public record struct GetDoAfterInterruptionBreakEvent(
     bool BreakOnMove,
     bool BreakOnHandChange,
-    bool BreakOnDropItem);
+    bool BreakOnDropItem,
+    bool ApplyMovementSlowdown = false);
+
+[ByRefEvent]
+public record struct DoAfterMovementSlowdownChangedEvent;

--- a/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptSystem.cs
+++ b/Content.Shared/_Exodus/DoAfter/DoAfterInterruptionExemptSystem.cs
@@ -1,10 +1,13 @@
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Systems;
+using Content.Shared._White.Standing;
+using Robust.Shared.Player;
 
 namespace Content.Shared._Exodus.DoAfter;
 
 public sealed class DoAfterInterruptionExemptSystem : EntitySystem
 {
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private MovementSpeedModifierSystem _movementSpeed = default!;
 
     public override void Initialize()
@@ -13,6 +16,7 @@ public sealed class DoAfterInterruptionExemptSystem : EntitySystem
         SubscribeLocalEvent<DoAfterInterruptionExemptComponent, GetDoAfterInterruptionBreakEvent>(OnGetDoAfterInterruptionBreak);
         SubscribeLocalEvent<DoAfterInterruptionExemptComponent, DoAfterMovementSlowdownChangedEvent>(OnDoAfterMovementSlowdownChanged);
         SubscribeLocalEvent<DoAfterInterruptionExemptComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
+        SubscribeNetworkEvent<ChangeLayingDownEvent>(OnChangeLayingDown);
     }
 
     private void OnGetDoAfterInterruptionBreak(Entity<DoAfterInterruptionExemptComponent> ent,
@@ -29,6 +33,35 @@ public sealed class DoAfterInterruptionExemptSystem : EntitySystem
 
         if (ent.Comp.Exemptions.HasFlag(DoAfterInterruptionExemptions.DropItem))
             args.BreakOnDropItem = false;
+    }
+
+    private void OnChangeLayingDown(ChangeLayingDownEvent ev, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } uid ||
+            !TryComp<DoAfterInterruptionExemptComponent>(uid, out var exemption))
+        {
+            return;
+        }
+
+        CancelMobileDoAfters((uid, exemption));
+    }
+
+    private void CancelMobileDoAfters(Entity<DoAfterInterruptionExemptComponent> ent)
+    {
+        if (!TryComp<DoAfterComponent>(ent, out var doAfter))
+            return;
+
+        var toCancel = new List<ushort>();
+        foreach (var (id, active) in doAfter.DoAfters)
+        {
+            if (active.Args.ApplyMovementSlowdown && !active.Cancelled && !active.Completed)
+                toCancel.Add(id);
+        }
+
+        foreach (var id in toCancel)
+        {
+            _doAfter.Cancel(ent.Owner, id, doAfter);
+        }
     }
 
     private void OnDoAfterMovementSlowdownChanged(Entity<DoAfterInterruptionExemptComponent> ent,

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -65,6 +65,8 @@
   - type: StandingState
   - type: DoAfterInterruptionExempt # Exodus do-after-interruption-exemption
     exemptions: [Movement, HandChange]
+    walkSpeedModifier: 0.5 # Exodus do-after-movement-slowdown
+    sprintSpeedModifier: 0.5 # Exodus do-after-movement-slowdown
   - type: MobState
     allowedStates:
     - Alive


### PR DESCRIPTION
## Описание PR
Добавил 50% замедление КПБ когда они что-то применяют.
R (ложиться) - отменяет действие. 

## Почему / Баланс
Нерф имбовости. КПБ мог просто на ходу раздеть игрока или взять в захват, не давая возможности убежать.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- tweak: КПБ теперь замедляются на 50% если начинают что-то применять с длительностью применения. R (лечь) - дополнительно отменяет действие.
