### PR TITLE
Fire console optimisation

### DIFF
--- a/Content.Client/_Mono/FireControl/UI/FireControlConsoleBoundUserInterface.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlConsoleBoundUserInterface.cs
@@ -1,6 +1,7 @@
 // Copyright Rane (elijahrane@gmail.com) 2025
 // All rights reserved. Relicensed under AGPL with permission
 
+using Content.Shared._Exodus.FireControl; // Exodus fire-control cursor optimization
 using Content.Shared._Mono.FireControl;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
@@ -29,8 +30,7 @@ public sealed class FireControlConsoleBoundUserInterface : BoundUserInterface
         {
             var netCoords = EntMan.GetNetCoordinates(coords);
 
-            // Send empty list of weapons for cursor tracking only when not clicking
-            // This allows guided missiles to follow the cursor without firing weapons
+            // Exodus: Cursor movement uses a dedicated lightweight message for guided projectiles.
             if (!_window.Radar.IsMouseDown())
             {
                 SendCursorUpdateMessage(netCoords);
@@ -86,8 +86,7 @@ public sealed class FireControlConsoleBoundUserInterface : BoundUserInterface
 
     private void SendCursorUpdateMessage(NetCoordinates coordinates)
     {
-        // Send an empty weapon list to indicate this is just a cursor update, not a firing action
-        SendMessage(new FireControlConsoleFireMessage(new List<NetEntity>(), coordinates));
+        SendMessage(new FireControlConsoleCursorPositionMessage(coordinates)); // Exodus fire-control cursor optimization
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
@@ -35,11 +35,6 @@ public sealed partial class FireControlWindow : FancyWindow
 
     private FireControlConsoleBoundInterfaceState? _currentState;
 
-    // Exodus-Start
-    private const float UpdateTimer = 1f;
-    private float _updateAccumulator;
-    // Exodus-End
-
     public FireControlWindow()
     {
         RobustXamlLoader.Load(this);
@@ -374,14 +369,7 @@ public sealed partial class FireControlWindow : FancyWindow
     protected override void FrameUpdate(FrameEventArgs args)
     {
         base.FrameUpdate(args);
-        _updateAccumulator += args.DeltaSeconds;
-
-        if (_updateAccumulator > UpdateTimer)
-        {
-            OnServerRefresh?.Invoke(); // a crutch, what can you make me?
-            _updateAccumulator = 0;
-        }
-
+        // Exodus: Full states are server-event-driven; only local progress needs per-frame updates.
         UpdateReloadProgress();
     }
 

--- a/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.Emitter.cs
+++ b/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.Emitter.cs
@@ -28,9 +28,16 @@ public partial class ShipShieldsSystem
     {
         SubscribeLocalEvent<ShipShieldEmitterComponent, ShieldDeflectedEvent>(OnShieldDeflected);
         SubscribeLocalEvent<ShipShieldEmitterComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<ShipShieldEmitterComponent, ComponentStartup>(OnEmitterStartup); // Exodus fire-control event-driven UI updates
         SubscribeLocalEvent<ShipShieldEmitterComponent, ComponentRemove>(OnRemoved);
     }
 
+    // Exodus-begin fire-control event-driven UI updates
+    private void OnEmitterStartup(Entity<ShipShieldEmitterComponent> owner, ref ComponentStartup args)
+    {
+        RaiseShieldStateChanged(Transform(owner).GridUid);
+    }
+    // Exodus-end
 
     private void OnRemoved(Entity<ShipShieldEmitterComponent> owner, ref ComponentRemove remove)
     {
@@ -38,6 +45,7 @@ public partial class ShipShieldsSystem
         if (parent is null)
             return;
         UnshieldEntity(parent.Value, null);
+        RaiseShieldStateChanged(parent); // Exodus fire-control event-driven UI updates
     }
 
     private void OnShieldDeflected(EntityUid uid, ShipShieldEmitterComponent component, ShieldDeflectedEvent args)
@@ -55,6 +63,8 @@ public partial class ShipShieldsSystem
 
         component.Damage += (float)args.Projectile.Damage.GetTotal();
         args.Projectile.ProjectileSpent = true;
+
+        RaiseShieldStateChanged(Transform(uid).GridUid); // Exodus fire-control event-driven UI updates
 
         QueueDel(args.Deflected);
     }

--- a/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.Exodus.cs
+++ b/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.Exodus.cs
@@ -73,6 +73,8 @@ public sealed partial class ShipShieldsSystem
         if (_apcPowerReceiverQuery.TryGetComponent(source, out var receiver))
             AdjustEmitterLoad(source, emitter, receiver);
 
+        RaiseShieldStateChanged(Transform(source).GridUid); // Exodus fire-control event-driven UI updates
+
         return true;
     }
 

--- a/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.cs
+++ b/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.cs
@@ -60,6 +60,13 @@ public sealed partial class ShipShieldsSystem : EntitySystem
             if (emitter.Accumulator < EmitterUpdateRate)
                 continue;
 
+            // Exodus-begin fire-control event-driven UI updates
+            var previousDamage = emitter.Damage;
+            var previousRecharging = emitter.Recharging;
+            var previousOverload = emitter.OverloadAccumulator;
+            var previousShield = emitter.Shield;
+            // Exodus-end
+
             if (CalculateLoadDamage(emitter) >= emitter.MaxDraw)
                 emitter.Recharging = true;
             if (!power.Powered)
@@ -122,6 +129,16 @@ public sealed partial class ShipShieldsSystem : EntitySystem
                 if (!HasComp<ShipShieldDisabledGridComponent>(Transform(uid).GridUid))
                     _audio.PlayGlobal(emitter.PowerDownSound, filter, true, emitter.PowerUpSound.Params);
             }
+
+            // Exodus-begin fire-control event-driven UI updates
+            if (!previousDamage.Equals(emitter.Damage)
+                || previousRecharging != emitter.Recharging
+                || !previousOverload.Equals(emitter.OverloadAccumulator)
+                || previousShield != emitter.Shield)
+            {
+                RaiseShieldStateChanged(parent);
+            }
+            // Exodus-end
         }
     }
 
@@ -241,12 +258,15 @@ public sealed partial class ShipShieldsSystem : EntitySystem
 
     private void OnEmitterShutdown(EntityUid uid, ShipShieldEmitterComponent emitter, ComponentShutdown args) // Mono
     {
+        var grid = Transform(uid).GridUid; // Exodus fire-control event-driven UI updates
         if (emitter.Shielded != null)
         {
             UnshieldEntity(emitter.Shielded.Value);
             emitter.Shield = null;
             emitter.Shielded = null;
         }
+
+        RaiseShieldStateChanged(grid); // Exodus fire-control event-driven UI updates
     }
 
     /// <summary>

--- a/Content.Server/_Exodus/FireControl/FireControlSystem.UiUpdates.cs
+++ b/Content.Server/_Exodus/FireControl/FireControlSystem.UiUpdates.cs
@@ -1,0 +1,306 @@
+using Content.Server._Crescent.ShipShields;
+using Content.Server._Exodus.SpaceArtillery;
+using Content.Server.Shuttles.Components;
+using Content.Server.Shuttles.Events;
+using Content.Shared._Mono.FireControl;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Containers;
+
+namespace Content.Server._Mono.FireControl;
+
+public sealed partial class FireControlSystem
+{
+    private static readonly TimeSpan UiUpdateInterval = TimeSpan.FromMilliseconds(250);
+
+    private readonly HashSet<EntityUid> _pendingUiServers = [];
+    private readonly HashSet<EntityUid> _pendingUiConsoles = [];
+    private readonly HashSet<EntityUid> _pendingUiGrids = [];
+    private readonly Dictionary<EntityUid, TimeSpan> _nextUiUpdates = [];
+    private readonly List<EntityUid> _processedUiConsoles = [];
+    private bool _queueAllUiConsoles;
+
+    private void InitializeUiUpdates()
+    {
+        SubscribeLocalEvent<FireControlConsoleComponent, ComponentStartup>(OnConsoleStartup);
+        SubscribeLocalEvent<FireControlConsoleComponent, AnchorStateChangedEvent>(OnConsoleAnchorChanged);
+        SubscribeLocalEvent<FireControlConsoleComponent, EntParentChangedMessage>(OnConsoleParentChanged);
+
+        SubscribeLocalEvent<FireControlServerComponent, ComponentStartup>(OnServerStartup);
+        SubscribeLocalEvent<FireControlServerComponent, AnchorStateChangedEvent>(OnServerAnchorChanged);
+        SubscribeLocalEvent<FireControlServerComponent, EntParentChangedMessage>(OnServerParentChanged);
+
+        SubscribeLocalEvent<FireControllableComponent, AnchorStateChangedEvent>(OnControllableAnchorChanged);
+        SubscribeLocalEvent<FireControllableComponent, ComponentStartup>(OnControllableStartup);
+        SubscribeLocalEvent<FireControllableComponent, EntityRenamedEvent>(OnControllableRenamed);
+        SubscribeLocalEvent<FireControllableComponent, GunShotEvent>(OnControllableGunShot);
+        SubscribeLocalEvent<FireControllableComponent, GunCycledEvent>(OnControllableGunCycled);
+        SubscribeLocalEvent<FireControllableComponent, OnEmptyGunShotEvent>(OnControllableEmptyShot);
+
+        SubscribeLocalEvent<FireControllableComponent, EntInsertedIntoContainerMessage>(OnControllableAmmoInserted);
+        SubscribeLocalEvent<FireControllableComponent, EntRemovedFromContainerMessage>(OnControllableAmmoRemoved);
+
+        SubscribeLocalEvent<DockingComponent, ComponentRemove>(OnDockingPortRemoved);
+        SubscribeLocalEvent<DockingComponent, EntParentChangedMessage>(OnDockingPortParentChanged);
+        SubscribeLocalEvent<DockingComponent, EntityRenamedEvent>(OnDockingPortRenamed);
+
+        SubscribeLocalEvent<ShipShieldStateChangedEvent>(OnShieldStateChanged);
+        SubscribeLocalEvent<DockEvent>(OnDockChanged);
+        SubscribeLocalEvent<UndockEvent>(OnUndockChanged);
+        SubscribeLocalEvent<ShipGrappleEvent>(OnShipGrappleChanged);
+        SubscribeLocalEvent<ShipUngrappleEvent>(OnShipUngrappleChanged);
+    }
+
+    private void OnConsoleStartup(Entity<FireControlConsoleComponent> ent, ref ComponentStartup args)
+    {
+        TryRegisterConsole(ent, ent.Comp);
+        QueueConsoleUiUpdate(ent);
+    }
+
+    private void OnConsoleAnchorChanged(Entity<FireControlConsoleComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        ReconnectConsole(ent);
+    }
+
+    private void OnConsoleParentChanged(Entity<FireControlConsoleComponent> ent, ref EntParentChangedMessage args)
+    {
+        ReconnectConsole(ent);
+    }
+
+    private void ReconnectConsole(Entity<FireControlConsoleComponent> ent)
+    {
+        UnregisterConsole(ent, ent.Comp);
+        TryRegisterConsole(ent, ent.Comp);
+        QueueConsoleUiUpdate(ent);
+    }
+
+    private void OnServerStartup(Entity<FireControlServerComponent> ent, ref ComponentStartup args)
+    {
+        TryConnect(ent, ent.Comp);
+    }
+
+    private void OnServerAnchorChanged(Entity<FireControlServerComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (args.Anchored)
+            TryConnect(ent, ent.Comp);
+        else
+            Disconnect(ent, ent.Comp);
+    }
+
+    private void OnServerParentChanged(Entity<FireControlServerComponent> ent, ref EntParentChangedMessage args)
+    {
+        Disconnect(ent, ent.Comp);
+        TryConnect(ent, ent.Comp);
+    }
+
+    private void OnControllableStartup(Entity<FireControllableComponent> ent, ref ComponentStartup args)
+    {
+        if (Transform(ent).Anchored && _power.IsPowered(ent) && TryRegister(ent, ent.Comp))
+            QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableAnchorChanged(Entity<FireControllableComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        var previousServer = ent.Comp.ControllingServer;
+
+        if (args.Anchored && _power.IsPowered(ent))
+        {
+            if (TryRegister(ent, ent.Comp))
+                QueueServerUiUpdate(ent.Comp.ControllingServer);
+
+            return;
+        }
+
+        Unregister(ent, ent.Comp);
+        QueueServerUiUpdate(previousServer);
+    }
+
+    private void OnControllableRenamed(Entity<FireControllableComponent> ent, ref EntityRenamedEvent args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableGunShot(Entity<FireControllableComponent> ent, ref GunShotEvent args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableGunCycled(Entity<FireControllableComponent> ent, ref GunCycledEvent args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableEmptyShot(Entity<FireControllableComponent> ent, ref OnEmptyGunShotEvent args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableAmmoInserted(Entity<FireControllableComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnControllableAmmoRemoved(Entity<FireControllableComponent> ent, ref EntRemovedFromContainerMessage args)
+    {
+        QueueServerUiUpdate(ent.Comp.ControllingServer);
+    }
+
+    private void OnDockingPortRemoved(Entity<DockingComponent> ent, ref ComponentRemove args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnDockingPortParentChanged(Entity<DockingComponent> ent, ref EntParentChangedMessage args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnDockingPortRenamed(Entity<DockingComponent> ent, ref EntityRenamedEvent args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnShieldStateChanged(ref ShipShieldStateChangedEvent args)
+    {
+        QueueGridConsoleUiUpdates(args.Grid);
+    }
+
+    private void OnDockChanged(DockEvent args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnUndockChanged(UndockEvent args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnShipGrappleChanged(ShipGrappleEvent args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void OnShipUngrappleChanged(ShipUngrappleEvent args)
+    {
+        QueueAllConsoleUiUpdates();
+    }
+
+    private void QueueAllConsoleUiUpdates()
+    {
+        _queueAllUiConsoles = true;
+    }
+
+    private void QueueGridConsoleUiUpdates(EntityUid grid)
+    {
+        _pendingUiGrids.Add(grid);
+    }
+
+    private void QueueServerUiUpdate(EntityUid? server)
+    {
+        if (server is { } uid)
+            _pendingUiServers.Add(uid);
+    }
+
+    private void QueueConsoleUiUpdate(EntityUid console)
+    {
+        if (!TerminatingOrDeleted(console))
+            _pendingUiConsoles.Add(console);
+    }
+
+    private void MarkConsoleUiUpdated(EntityUid console)
+    {
+        _pendingUiConsoles.Remove(console);
+        if (_ui.IsUiOpen(console, FireControlConsoleUiKey.Key))
+            _nextUiUpdates[console] = _timing.CurTime + UiUpdateInterval;
+        else
+            _nextUiUpdates.Remove(console);
+    }
+
+    private void ProcessPendingUiUpdates()
+    {
+        if (_pendingUiServers.Count == 0
+            && _pendingUiConsoles.Count == 0
+            && _pendingUiGrids.Count == 0
+            && !_queueAllUiConsoles)
+        {
+            return;
+        }
+
+        if (_queueAllUiConsoles)
+        {
+            var allConsoles = EntityQueryEnumerator<FireControlConsoleComponent>();
+            while (allConsoles.MoveNext(out var uid, out _))
+            {
+                if (_ui.IsUiOpen(uid, FireControlConsoleUiKey.Key))
+                    _pendingUiConsoles.Add(uid);
+            }
+
+            _queueAllUiConsoles = false;
+            _pendingUiGrids.Clear();
+        }
+        else if (_pendingUiGrids.Count != 0)
+        {
+            var gridConsoles = EntityQueryEnumerator<FireControlConsoleComponent, TransformComponent>();
+            while (gridConsoles.MoveNext(out var uid, out _, out var xform))
+            {
+                if (xform.GridUid is { } grid
+                    && _pendingUiGrids.Contains(grid)
+                    && _ui.IsUiOpen(uid, FireControlConsoleUiKey.Key))
+                {
+                    _pendingUiConsoles.Add(uid);
+                }
+            }
+
+            _pendingUiGrids.Clear();
+        }
+
+        foreach (var serverUid in _pendingUiServers)
+        {
+            if (!TryComp<FireControlServerComponent>(serverUid, out var server))
+                continue;
+
+            foreach (var console in server.Consoles)
+                _pendingUiConsoles.Add(console);
+        }
+
+        _pendingUiServers.Clear();
+
+        var curTime = _timing.CurTime;
+        _processedUiConsoles.Clear();
+        foreach (var console in _pendingUiConsoles)
+        {
+            if (!TryComp<FireControlConsoleComponent>(console, out var component)
+                || !_ui.IsUiOpen(console, FireControlConsoleUiKey.Key))
+            {
+                _nextUiUpdates.Remove(console);
+                _processedUiConsoles.Add(console);
+                continue;
+            }
+
+            if (_nextUiUpdates.TryGetValue(console, out var nextUpdate) && nextUpdate > curTime)
+                continue;
+
+            UpdateUi(console, component);
+            _nextUiUpdates[console] = curTime + UiUpdateInterval;
+            _processedUiConsoles.Add(console);
+        }
+
+        foreach (var console in _processedUiConsoles)
+            _pendingUiConsoles.Remove(console);
+    }
+
+    private void RegisterPoweredConsolesOnGrid(EntityUid grid)
+    {
+        var query = EntityQueryEnumerator<FireControlConsoleComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var console, out var xform))
+        {
+            if (xform.GridUid != grid)
+                continue;
+
+            var previousServer = console.ConnectedServer;
+            TryRegisterConsole(uid, console);
+            if (previousServer != console.ConnectedServer)
+                QueueConsoleUiUpdate(uid);
+        }
+    }
+}

--- a/Content.Server/_Exodus/ShipShields/ShipShieldsSystem.UiEvents.cs
+++ b/Content.Server/_Exodus/ShipShields/ShipShieldsSystem.UiEvents.cs
@@ -1,0 +1,16 @@
+namespace Content.Server._Crescent.ShipShields;
+
+public sealed partial class ShipShieldsSystem
+{
+    private void RaiseShieldStateChanged(EntityUid? grid)
+    {
+        if (grid is not { } uid || TerminatingOrDeleted(uid))
+            return;
+
+        var ev = new ShipShieldStateChangedEvent(uid);
+        RaiseLocalEvent(ref ev);
+    }
+}
+
+[ByRefEvent]
+public readonly record struct ShipShieldStateChangedEvent(EntityUid Grid);

--- a/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
@@ -6,7 +6,6 @@ using Content.Server.Administration.Logs;
 using Content.Server.Shuttles.Systems;
 using Content.Shared._Mono.FireControl;
 using Content.Shared.Database;
-using Content.Shared.GameTicking;
 using Content.Shared._Mono.Ships.Components;
 using Content.Shared.Popups;
 using Content.Shared.Power;
@@ -19,10 +18,10 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
-using System.Linq;
 using System.Numerics;
 using Content.Server._Crescent.ShipShields; // Exodus
 using Content.Server._Exodus.Territory; // Exodus territory fire logs
+using Content.Shared._Exodus.FireControl; // Exodus fire-control cursor optimization
 
 namespace Content.Server._Mono.FireControl;
 
@@ -39,35 +38,16 @@ public sealed partial class FireControlSystem : EntitySystem
     [Dependency] private ShipShieldsSystem _shields = default!; // Exodus
     [Dependency] private GridTerritorySystem _territory = default!; // Exodus territory fire logs
 
-    private bool _completedCheck = false;
-
     private void InitializeConsole()
     {
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
-
+        // Exodus: Component lifecycle events replace the previous player-spawn-wide refresh.
         SubscribeLocalEvent<FireControlConsoleComponent, PowerChangedEvent>(OnPowerChanged);
         SubscribeLocalEvent<FireControlConsoleComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleRefreshServerMessage>(OnRefreshServer);
         SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleFireMessage>(OnFire);
+        SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleCursorPositionMessage>(OnCursorPosition); // Exodus fire-control cursor optimization
         SubscribeLocalEvent<FireControlConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
         SubscribeLocalEvent<FireControlConsoleComponent, ActivatableUIOpenAttemptEvent>(OnConsoleUIOpenAttempt);
-    }
-
-    // scuffed one-time check of all station control consoles to ensure they're already refreshed
-    // given this only happens once, we can assume all refreshed are things like Camelot's gunnery server.
-    private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
-    {
-        if (_completedCheck)
-            return;
-
-        var query = EntityQueryEnumerator<FireControlConsoleComponent>();
-
-        while (query.MoveNext(out var uid, out var console))
-        {
-            DoRefreshServer(uid, console);
-        }
-
-        _completedCheck = true;
     }
 
     private void OnPowerChanged(EntityUid uid, FireControlConsoleComponent component, PowerChangedEvent args)
@@ -76,11 +56,15 @@ public sealed partial class FireControlSystem : EntitySystem
             TryRegisterConsole(uid, component);
         else
             UnregisterConsole(uid, component);
+
+        QueueConsoleUiUpdate(uid); // Exodus fire-control event-driven UI updates
     }
 
     private void OnComponentShutdown(EntityUid uid, FireControlConsoleComponent component, ComponentShutdown args)
     {
         UnregisterConsole(uid, component);
+        _pendingUiConsoles.Remove(uid); // Exodus fire-control event-driven UI updates
+        _nextUiUpdates.Remove(uid); // Exodus fire-control event-driven UI updates
     }
 
     private void DoRefreshServer(EntityUid uid, FireControlConsoleComponent component)
@@ -96,32 +80,19 @@ public sealed partial class FireControlSystem : EntitySystem
             ForceServerReconnectionOnGrid((EntityUid)consoleGrid);
         }
 
-        // Check if the current connected server is still valid
-        if (component.ConnectedServer != null)
-        {
-            if (!Exists(component.ConnectedServer) || !TryComp<FireControlServerComponent>(component.ConnectedServer, out _))
-            {
-                // Server no longer exists, clear the connection
-                component.ConnectedServer = null;
-            }
-        }
-
-        // Try to register console if not connected or if connection was cleared
-        if (component.ConnectedServer == null)
-        {
-            TryRegisterConsole(uid, component);
-        }
+        TryRegisterConsole(uid, component); // Exodus fire-control event-driven UI updates
 
         // Refresh controllables if we have a valid server connection
         if (component.ConnectedServer != null &&
             TryComp<FireControlServerComponent>(component.ConnectedServer, out var server) &&
             server.ConnectedGrid != null)
         {
-            RefreshControllables((EntityUid)server.ConnectedGrid);
+            RefreshControllables((EntityUid)server.ConnectedGrid, immediateConsole: uid); // Exodus fire-control event-driven UI updates
         }
 
         // Always update UI to reflect current state
         UpdateUi(uid, component);
+        MarkConsoleUiUpdated(uid); // Exodus fire-control event-driven UI updates
     }
 
     private void OnRefreshServer(EntityUid uid, FireControlConsoleComponent component, FireControlConsoleRefreshServerMessage args)
@@ -138,14 +109,28 @@ public sealed partial class FireControlSystem : EntitySystem
 
         var xform = Transform(uid);
         var grid = xform.GridUid;
-        if (grid == null)
+        if (grid == null || server.ConnectedGrid != grid) // Exodus fire-control cursor optimization
             return;
 
-        // Fire the actual weapons
-        FireWeapons((EntityUid)component.ConnectedServer, args.Selected, args.Coordinates, args.Actor, server); // Exodus-AdminQoL: Provide user triggered auto-shooting
-        if ((component.NextLog == null || component.NextLog < _timing.CurTime) && args.Selected.Any())
+        var coordinates = GetCoordinates(args.Coordinates); // Exodus fire-control cursor optimization
+        if (!coordinates.IsValid(EntityManager)) // Exodus fire-control cursor optimization
+            return;
+
+        // Exodus-begin fire-control cursor optimization
+        // Keep legacy empty fire messages lightweight as well as using the dedicated cursor message.
+        if (args.Selected.Count == 0)
         {
-            var fireCoordinates = _transform.ToMapCoordinates(GetCoordinates(args.Coordinates)); // Exodus territory fire logs
+            RaiseCursorPosition(uid, coordinates);
+            return;
+        }
+        // Exodus-end
+
+        // Fire the actual weapons
+        FireWeapons((EntityUid)component.ConnectedServer, args.Selected, args.Coordinates, args.Actor, server, uid); // Exodus fire-control cursor optimization
+
+        if (component.NextLog == null || component.NextLog < _timing.CurTime)
+        {
+            var fireCoordinates = _transform.ToMapCoordinates(coordinates); // Exodus territory fire logs
             var firePos = fireCoordinates.Position; // Exodus territory fire logs
             var ourPos = _transform.GetWorldPosition(grid.Value);
             var grids = new List<Entity<MapGridComponent>>();
@@ -178,16 +163,44 @@ public sealed partial class FireControlSystem : EntitySystem
             component.NextLog = _timing.CurTime + component.LogSpacing;
         }
 
-        UpdateUi(uid, component);
-
-        // Raise an event to track the cursor position even when not firing
-        var fireEvent = new FireControlConsoleFireEvent(args.Coordinates, args.Selected);
-        RaiseLocalEvent(uid, fireEvent);
+        // Exodus-begin fire-control cursor optimization
+        RaiseCursorPosition(uid, coordinates);
+        // Exodus-end
     }
+
+    // Exodus-begin fire-control cursor optimization
+    private void OnCursorPosition(Entity<FireControlConsoleComponent> ent, ref FireControlConsoleCursorPositionMessage args)
+    {
+        if (!_consoleMousePositions.ContainsKey(ent))
+            return;
+
+        var grid = Transform(ent).GridUid;
+        if (grid == null
+            || ent.Comp.ConnectedServer == null
+            || !TryComp<FireControlServerComponent>(ent.Comp.ConnectedServer, out var server)
+            || !server.Consoles.Contains(ent)
+            || server.ConnectedGrid != grid)
+        {
+            return;
+        }
+
+        var coordinates = GetCoordinates(args.Coordinates);
+        if (!coordinates.IsValid(EntityManager))
+            return;
+
+        RaiseCursorPosition(ent, coordinates);
+    }
+
+    private void RaiseCursorPosition(EntityUid console, EntityCoordinates coordinates)
+    {
+        var cursorEvent = new FireControlConsoleCursorPositionEvent(coordinates);
+        RaiseLocalEvent(console, ref cursorEvent);
+    }
+    // Exodus-end
 
     public void OnUIOpened(EntityUid uid, FireControlConsoleComponent component, BoundUIOpenedEvent args)
     {
-        UpdateUi(uid, component);
+        DoRefreshServer(uid, component); // Exodus fire-control event-driven UI updates
     }
 
     private void OnConsoleUIOpenAttempt(
@@ -222,7 +235,6 @@ public sealed partial class FireControlSystem : EntitySystem
         }
 
         component.ConnectedServer = null;
-        UpdateUi(console, component);
     }
 
     private bool CanRegister((EntityUid? ServerUid, FireControlServerComponent? ServerComponent) gridServer)
@@ -242,26 +254,35 @@ public sealed partial class FireControlSystem : EntitySystem
         if (!Resolve(console, ref consoleComponent))
             return false;
 
-        // Clear any existing invalid connection first
-        if (consoleComponent.ConnectedServer != null)
-        {
-            if (!Exists(consoleComponent.ConnectedServer) || !TryComp<FireControlServerComponent>(consoleComponent.ConnectedServer, out _))
-            {
-                consoleComponent.ConnectedServer = null;
-            }
-        }
-
+        // Exodus-begin fire-control event-driven UI updates
+        var canOperate = Transform(console).Anchored && _power.IsPowered(console);
         var gridServer = TryGetGridServer(console);
 
-        if (gridServer.ServerUid == null || gridServer.ServerComponent == null)
+        if (consoleComponent.ConnectedServer is { } connectedServer)
+        {
+            var connectionValid = canOperate
+                && gridServer.ServerUid == connectedServer
+                && gridServer.ServerComponent != null
+                && gridServer.ServerComponent.Consoles.Contains(console);
+
+            if (connectionValid)
+                return true;
+
+            if (TryComp<FireControlServerComponent>(connectedServer, out var previousServer))
+                previousServer.Consoles.Remove(console);
+
+            consoleComponent.ConnectedServer = null;
+        }
+
+        if (!canOperate || gridServer.ServerUid == null || gridServer.ServerComponent == null)
             return false;
+        // Exodus-end
 
         var canRegister = CanRegister(gridServer);
 
         if (canRegister && gridServer.ServerComponent.Consoles.Add(console))
         {
             consoleComponent.ConnectedServer = gridServer.ServerUid;
-            UpdateUi(console, consoleComponent);
             return true;
         }
 
@@ -271,6 +292,9 @@ public sealed partial class FireControlSystem : EntitySystem
     private void UpdateUi(EntityUid uid, FireControlConsoleComponent? component = null)
     {
         if (!Resolve(uid, ref component))
+            return;
+
+        if (!_ui.IsUiOpen(uid, FireControlConsoleUiKey.Key)) // Exodus fire-control event-driven UI updates
             return;
 
         NavInterfaceState navState = _shuttleConsoleSystem.GetNavState(uid, _shuttleConsoleSystem.GetAllDocks(), _shuttleConsoleSystem.GetAllGrapLinks()); // Exodus - ShuttleHooks

--- a/Content.Server/_Mono/FireControl/FireControlSystem.TargetGuided.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.TargetGuided.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server._Mono.Projectiles.TargetGuided;
+using Content.Shared._Exodus.FireControl; // Exodus fire-control cursor optimization
 using Content.Shared._Mono.FireControl;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Components;
@@ -23,6 +24,11 @@ public sealed partial class FireControlSystem
     /// </summary>
     private readonly Dictionary<EntityUid, EntityCoordinates> _consoleMousePositions = new();
 
+    // Exodus-begin fire-control cursor optimization
+    private readonly HashSet<EntityUid> _consoleFiringWeapons = new();
+    private readonly List<EntityUid> _finishedConsoleFiringWeapons = new();
+    // Exodus-end
+
     /// <summary>
     /// Registers handlers for events related to target guided projectiles.
     /// </summary>
@@ -30,17 +36,18 @@ public sealed partial class FireControlSystem
     {
         SubscribeLocalEvent<GunComponent, AmmoShotEvent>(OnTargetGuidedShot);
         SubscribeLocalEvent<TargetGuidedComponent, ComponentShutdown>(OnGuidedMissileShutdown);
-        // Track fire messages to update cursor positions
-        SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleFireEvent>(OnConsoleFireEvent);
+        SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleCursorPositionEvent>(OnConsoleCursorPosition); // Exodus fire-control cursor optimization
     }
 
     /// <summary>
-    /// Track console fire events to update cursor positions
+    /// Track console cursor events to update guided projectile targets.
     /// </summary>
-    private void OnConsoleFireEvent(EntityUid uid, FireControlConsoleComponent component, FireControlConsoleFireEvent args)
+    private void OnConsoleCursorPosition(Entity<FireControlConsoleComponent> ent, ref FireControlConsoleCursorPositionEvent args) // Exodus fire-control cursor optimization
     {
-        // Store the current mouse position for this console
-        _consoleMousePositions[uid] = GetCoordinates(args.Coordinates);
+        if (!_consoleMousePositions.ContainsKey(ent))
+            return;
+
+        _consoleMousePositions[ent] = args.Coordinates;
     }
 
     /// <summary>
@@ -66,25 +73,27 @@ public sealed partial class FireControlSystem
         // Find the controlling console for position updates if this is a fire controllable
         EntityUid? controllingConsole = null;
         if (TryComp<FireControllableComponent>(uid, out var fireControllable) &&
-            fireControllable.ControllingServer != null)
+            fireControllable.ControllingServer is { } controllingServer)
         {
-            // Find the active console that fired this
-            var query = EntityQueryEnumerator<FireControlConsoleComponent>();
-            while (query.MoveNext(out var consoleUid, out var console))
+            // Exodus-begin fire-control cursor optimization
+            if (fireControllable.ActiveFiringConsole is { } firingConsole
+                && fireControllable.ActiveFiringUser == shooter
+                && TryComp<FireControlConsoleComponent>(firingConsole, out var firingConsoleComponent)
+                && firingConsoleComponent.ConnectedServer == controllingServer
+                && TryComp<FireControlServerComponent>(controllingServer, out var server)
+                && server.Consoles.Contains(firingConsole))
             {
-                if (console.ConnectedServer == fireControllable.ControllingServer)
-                {
-                    controllingConsole = consoleUid;
+                controllingConsole = firingConsole;
 
-                    // Store initial cursor position if we're seeing it for the first time
-                    if (!_consoleMousePositions.ContainsKey(consoleUid))
-                    {
-                        _consoleMousePositions[consoleUid] = targetCoords.Value;
-                    }
-
-                    break;
-                }
+                if (!_consoleMousePositions.ContainsKey(firingConsole))
+                    _consoleMousePositions[firingConsole] = targetCoords.Value;
             }
+            else if (fireControllable.ActiveFiringConsole != null)
+            {
+                // A shot from another source must not inherit an earlier console's cursor.
+                ClearConsoleFireSource(uid, fireControllable);
+            }
+            // Exodus-end
         }
 
         foreach (var projectileUid in args.FiredProjectiles)
@@ -196,7 +205,38 @@ public sealed partial class FireControlSystem
 
         // Clean up any console positions for consoles that no longer exist or have no active missiles
         CleanupConsolePositions();
+        CleanupConsoleFireSources(); // Exodus fire-control cursor optimization
+        ProcessPendingUiUpdates(); // Exodus fire-control event-driven UI updates
     }
+
+    // Exodus-begin fire-control cursor optimization
+    private void CleanupConsoleFireSources()
+    {
+        if (_consoleFiringWeapons.Count == 0)
+            return;
+
+        _finishedConsoleFiringWeapons.Clear();
+        foreach (var weapon in _consoleFiringWeapons)
+        {
+            if (!TryComp<FireControllableComponent>(weapon, out var controllable))
+            {
+                _finishedConsoleFiringWeapons.Add(weapon);
+                continue;
+            }
+
+            if (!_gunQuery.TryComp(weapon, out var gun)
+                || !_autoShootQuery.TryComp(weapon, out var autoShoot)
+                || autoShoot.RemainingTime <= TimeSpan.Zero && !gun.BurstActivated)
+            {
+                ResetConsoleFireSource(controllable);
+                _finishedConsoleFiringWeapons.Add(weapon);
+            }
+        }
+
+        foreach (var weapon in _finishedConsoleFiringWeapons)
+            _consoleFiringWeapons.Remove(weapon);
+    }
+    // Exodus-end
 
     /// <summary>
     /// Remove any console positions that no longer have active missiles

--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -26,6 +26,8 @@ namespace Content.Server._Mono.FireControl;
 
 public sealed partial class FireControlSystem : EntitySystem
 {
+    private static readonly TimeSpan ConsoleFireDuration = TimeSpan.FromSeconds(0.2); // Exodus fire-control cursor optimization
+
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private GunSystem _gun = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
@@ -39,6 +41,7 @@ public sealed partial class FireControlSystem : EntitySystem
     private readonly HashSet<EntityUid> _visualizedEntities = new();
 
     private EntityQuery<SpaceArtilleryComponent> _artilleryQuery;
+    private EntityQuery<AutoShootGunComponent> _autoShootQuery; // Exodus fire-control cursor optimization
     private EntityQuery<FireControlRotateComponent> _fireRotateQuery;
     private EntityQuery<GunComponent> _gunQuery;
 
@@ -59,8 +62,10 @@ public sealed partial class FireControlSystem : EntitySystem
 
         InitializeConsole();
         InitializeTargetGuided();
+        InitializeUiUpdates(); // Exodus fire-control event-driven UI updates
 
         _artilleryQuery = GetEntityQuery<SpaceArtilleryComponent>();
+        _autoShootQuery = GetEntityQuery<AutoShootGunComponent>(); // Exodus fire-control cursor optimization
         _fireRotateQuery = GetEntityQuery<FireControlRotateComponent>();
         _gunQuery = GetEntityQuery<GunComponent>();
     }
@@ -100,59 +105,62 @@ public sealed partial class FireControlSystem : EntitySystem
 
     private void OnControllablePowerChanged(EntityUid uid, FireControllableComponent component, PowerChangedEvent args)
     {
-        if (args.Powered)
-            TryRegister(uid, component);
+        var previousServer = component.ControllingServer; // Exodus fire-control event-driven UI updates
+
+        if (args.Powered && Transform(uid).Anchored) // Exodus fire-control event-driven UI updates
+        {
+            if (TryRegister(uid, component))
+                QueueServerUiUpdate(component.ControllingServer); // Exodus fire-control event-driven UI updates
+        }
         else
+        {
             Unregister(uid, component);
+            QueueServerUiUpdate(previousServer); // Exodus fire-control event-driven UI updates
+        }
     }
 
     private void OnControllableShutdown(EntityUid uid, FireControllableComponent component, ComponentShutdown args)
     {
-        if (component.ControllingServer != null && TryComp<FireControlServerComponent>(component.ControllingServer, out var server))
-        {
-            Unregister(uid, component);
-
-            foreach (var console in server.Consoles)
-            {
-                if (TryComp<FireControlConsoleComponent>(console, out var consoleComp))
-                {
-                    UpdateUi(console, consoleComp);
-                }
-            }
-        }
+        // Exodus-begin fire-control event-driven UI updates
+        var previousServer = component.ControllingServer;
+        ClearConsoleFireSource(uid, component); // Exodus fire-control cursor optimization
+        Unregister(uid, component);
+        QueueServerUiUpdate(previousServer);
+        // Exodus-end
     }
 
     private void OnControllableParentChanged(EntityUid uid, FireControllableComponent component, ref EntParentChangedMessage args)
     {
-        if (component.ControllingServer == null)
-            return;
-
-        // Check if the weapon is still on the same grid as its controlling server
-        if (!TryComp<FireControlServerComponent>(component.ControllingServer, out var server) ||
-            server.ConnectedGrid == null)
-            return;
-
+        // Exodus-begin fire-control event-driven UI updates
+        var previousServer = component.ControllingServer;
         var currentGrid = _xform.GetGrid(uid);
-        if (currentGrid != server.ConnectedGrid)
-        {
-            // Weapon is no longer on the same grid - unregister it
-            Unregister(uid, component);
 
-            // Update UI for any connected consoles
-            foreach (var console in server.Consoles)
-            {
-                if (TryComp<FireControlConsoleComponent>(console, out var consoleComp))
-                {
-                    UpdateUi(console, consoleComp);
-                }
-            }
+        if (previousServer is { } serverUid)
+        {
+            if (!TryComp<FireControlServerComponent>(serverUid, out var server))
+                component.ControllingServer = null;
+            else if (server.ConnectedGrid == null || currentGrid != server.ConnectedGrid)
+                Unregister(uid, component);
         }
+
+        if (component.ControllingServer == null
+            && Transform(uid).Anchored
+            && _power.IsPowered(uid))
+        {
+            TryRegister(uid, component);
+        }
+
+        QueueServerUiUpdate(previousServer);
+        QueueServerUiUpdate(component.ControllingServer);
+        // Exodus-end
     }
 
     private void Disconnect(EntityUid server, FireControlServerComponent? component = null)
     {
         if (!Resolve(server, ref component))
             return;
+
+        var previousGrid = component.ConnectedGrid; // Exodus fire-control event-driven UI updates
 
         // Clean up grid connection if it exists
         if (component.ConnectedGrid != null && Exists(component.ConnectedGrid) && TryComp<FireControlGridComponent>(component.ConnectedGrid, out var controlGrid))
@@ -177,7 +185,10 @@ public sealed partial class FireControlSystem : EntitySystem
         foreach (var console in consolesCopy)
         {
             if (Exists(console))
+            {
                 UnregisterConsole(console);
+                QueueConsoleUiUpdate(console); // Exodus fire-control event-driven UI updates
+            }
         }
 
         // Clear the server's state
@@ -185,9 +196,15 @@ public sealed partial class FireControlSystem : EntitySystem
         component.Consoles.Clear();
         component.ConnectedGrid = null;
         component.UsedProcessingPower = 0;
+
+        if (previousGrid is { } grid && !TerminatingOrDeleted(grid))
+            ForceServerReconnectionOnGrid(grid, server); // Exodus fire-control event-driven UI updates
     }
 
-    public void RefreshControllables(EntityUid grid, FireControlGridComponent? component = null)
+    public void RefreshControllables(
+        EntityUid grid,
+        FireControlGridComponent? component = null,
+        EntityUid? immediateConsole = null) // Exodus fire-control event-driven UI updates
     {
         if (!Resolve(grid, ref component))
             return;
@@ -210,18 +227,27 @@ public sealed partial class FireControlSystem : EntitySystem
 
         while (query.MoveNext(out var controllable, out var controlComp))
         {
-            if (_xform.GetGrid(controllable) == grid && EntityManager.GetComponent<TransformComponent>(controllable).Anchored)
+            if (_xform.GetGrid(controllable) == grid
+                && EntityManager.GetComponent<TransformComponent>(controllable).Anchored
+                && _power.IsPowered(controllable)) // Exodus fire-control event-driven UI updates
                 TryRegister(controllable, controlComp);
         }
 
         foreach (var console in server.Consoles)
-            UpdateUi(console);
+        {
+            if (console != immediateConsole)
+                QueueConsoleUiUpdate(console); // Exodus fire-control event-driven UI updates
+        }
     }
 
     private bool TryConnect(EntityUid server, FireControlServerComponent? component = null)
     {
-        if (!Resolve(server, ref component))
+        if (!Resolve(server, ref component)
+            || !Transform(server).Anchored
+            || !_power.IsPowered(server)) // Exodus fire-control event-driven UI updates
+        {
             return false;
+        }
 
         var grid = _xform.GetGrid(server);
 
@@ -238,6 +264,14 @@ public sealed partial class FireControlSystem : EntitySystem
             {
                 controlGrid.ControllingServer = null;
             }
+            // Exodus-begin fire-control event-driven UI updates
+            else if (controlGrid.ControllingServer == server)
+            {
+                component.ConnectedGrid = grid;
+                RegisterPoweredConsolesOnGrid(grid.Value);
+                return true;
+            }
+            // Exodus-end
             else
             {
                 // Valid server already exists, cannot connect
@@ -249,6 +283,7 @@ public sealed partial class FireControlSystem : EntitySystem
         component.ConnectedGrid = grid;
 
         RefreshControllables((EntityUid)grid, controlGrid);
+        RegisterPoweredConsolesOnGrid(grid.Value); // Exodus fire-control event-driven UI updates
 
         return true;
     }
@@ -268,8 +303,12 @@ public sealed partial class FireControlSystem : EntitySystem
 
     private bool TryRegister(EntityUid controllable, FireControllableComponent? component = null)
     {
-        if (!Resolve(controllable, ref component))
+        if (!Resolve(controllable, ref component)
+            || !Transform(controllable).Anchored
+            || !_power.IsPowered(controllable)) // Exodus fire-control event-driven UI updates
+        {
             return false;
+        }
 
         var gridServer = TryGetGridServer(controllable);
 
@@ -370,17 +409,19 @@ public sealed partial class FireControlSystem : EntitySystem
     /// <summary>
     /// Forces all powered servers on a specific grid to attempt reconnection
     /// </summary>
-    public void ForceServerReconnectionOnGrid(EntityUid gridUid)
+    public void ForceServerReconnectionOnGrid(EntityUid gridUid, EntityUid? excludedServer = null) // Exodus fire-control event-driven UI updates
     {
         var serverQuery = EntityQueryEnumerator<FireControlServerComponent>();
 
         while (serverQuery.MoveNext(out var serverUid, out var serverComponent))
         {
+            if (serverUid == excludedServer || TerminatingOrDeleted(serverUid)) // Exodus fire-control event-driven UI updates
+                continue;
+
             var serverGrid = _xform.GetGrid(serverUid);
-            if (serverGrid == gridUid && _power.IsPowered(serverUid))
+            if (serverGrid == gridUid && TryConnect(serverUid, serverComponent)) // Exodus fire-control event-driven UI updates
             {
-                // Force reconnection attempt
-                TryConnect(serverUid, serverComponent);
+                break; // Exodus fire-control event-driven UI updates
             }
         }
     }
@@ -401,7 +442,13 @@ public sealed partial class FireControlSystem : EntitySystem
         return true;
     }
 
-    public void FireWeapons(EntityUid server, List<NetEntity> weapons, NetCoordinates coordinates, EntityUid user, FireControlServerComponent? component = null) // Exodus-AdminQoL: Provide user triggered auto-shooting
+    public void FireWeapons(
+        EntityUid server,
+        List<NetEntity> weapons,
+        NetCoordinates coordinates,
+        EntityUid user,
+        FireControlServerComponent? component = null,
+        EntityUid? firingConsole = null) // Exodus fire-control cursor optimization
     {
         if (!Resolve(server, ref component))
             return;
@@ -416,10 +463,19 @@ public sealed partial class FireControlSystem : EntitySystem
         foreach (var weapon in weapons)
         {
             var localWeapon = GetEntity(weapon);
-            if (!Exists(localWeapon) || !component.Controlled.Contains(localWeapon))
+            if (!Exists(localWeapon)
+                || !component.Controlled.Contains(localWeapon)
+                || !TryComp<FireControllableComponent>(localWeapon, out var controllable))
+            {
                 continue;
+            }
 
-            var fired = AttemptFire(localWeapon, user, targetCoords); // Exodus-AdminQoL
+            var fired = AttemptFire(
+                localWeapon,
+                user,
+                targetCoords,
+                controllable,
+                firingConsole: firingConsole); // Exodus fire-control cursor optimization
 
             artilleryFired |= _artilleryQuery.HasComp(localWeapon) && fired;
         }
@@ -450,14 +506,7 @@ public sealed partial class FireControlSystem : EntitySystem
             }
         }
 
-        // Update UI for all consoles
-        foreach (var console in component.Consoles)
-        {
-            if (TryComp<FireControlConsoleComponent>(console, out var consoleComp))
-            {
-                UpdateUi(console, consoleComp);
-            }
-        }
+        QueueServerUiUpdate(server); // Exodus fire-control event-driven UI updates
     }
 
     private void OnGridSplit(ref GridSplitEvent ev)
@@ -478,7 +527,13 @@ public sealed partial class FireControlSystem : EntitySystem
     /// <summary>
     /// Attempts to fire a weapon, handling aiming and firing logic.
     /// </summary>
-    public bool AttemptFire(EntityUid weapon, EntityUid user, EntityCoordinates coords, FireControllableComponent? comp = null, bool noServer = false)
+    public bool AttemptFire(
+        EntityUid weapon,
+        EntityUid user,
+        EntityCoordinates coords,
+        FireControllableComponent? comp = null,
+        bool noServer = false,
+        EntityUid? firingConsole = null) // Exodus fire-control cursor optimization
     {
         if (!Resolve(weapon, ref comp))
             return false;
@@ -519,12 +574,39 @@ public sealed partial class FireControlSystem : EntitySystem
         // Try to get a gun component and fire the weapon
         if (_gunQuery.TryComp(weapon, out var gun))
         {
-            _gun.AttemptShots(user, weapon, gun, coords, TimeSpan.FromSeconds(0.2));
+            // Exodus-begin fire-control cursor optimization
+            if (firingConsole is { } console)
+            {
+                comp.ActiveFiringConsole = console;
+                comp.ActiveFiringUser = user;
+                _consoleFiringWeapons.Add(weapon);
+            }
+            else
+            {
+                ClearConsoleFireSource(weapon, comp);
+            }
+
+            _gun.AttemptShots(user, weapon, gun, coords, ConsoleFireDuration);
+            // Exodus-end
             return true;
         }
 
         return false;
     }
+
+    // Exodus-begin fire-control cursor optimization
+    private void ClearConsoleFireSource(EntityUid weapon, FireControllableComponent component)
+    {
+        ResetConsoleFireSource(component);
+        _consoleFiringWeapons.Remove(weapon);
+    }
+
+    private static void ResetConsoleFireSource(FireControllableComponent component)
+    {
+        component.ActiveFiringConsole = null;
+        component.ActiveFiringUser = null;
+    }
+    // Exodus-end
 
     /// <summary>
     /// Checks if a weapon is ready to fire.

--- a/Content.Server/_Mono/FireControl/FireControllableComponent.cs
+++ b/Content.Server/_Mono/FireControl/FireControllableComponent.cs
@@ -14,6 +14,20 @@ public sealed partial class FireControllableComponent : Component
     [ViewVariables]
     public EntityUid? ControllingServer = null;
 
+    // Exodus-begin fire-control cursor optimization
+    /// <summary>
+    /// Console responsible for the current short auto-fire request.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? ActiveFiringConsole;
+
+    /// <summary>
+    /// User whose shots belong to the active firing console.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? ActiveFiringUser;
+    // Exodus-end
+
     /// <summary>
     /// When the weapon can next be fired
     /// </summary>

--- a/Content.Shared/_Exodus/FireControl/FireControlCursorPositionMessage.cs
+++ b/Content.Shared/_Exodus/FireControl/FireControlCursorPositionMessage.cs
@@ -1,0 +1,14 @@
+using Content.Shared.UserInterface;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Exodus.FireControl;
+
+[Serializable, NetSerializable]
+public sealed class FireControlConsoleCursorPositionMessage(NetCoordinates coordinates) : BoundUserInterfaceMessage
+{
+    public NetCoordinates Coordinates { get; } = coordinates;
+}
+
+[ByRefEvent]
+public readonly record struct FireControlConsoleCursorPositionEvent(EntityCoordinates Coordinates);


### PR DESCRIPTION
## Описание PR
Оптимизирована работа орудийной консоли. Убраны лишние полные обновления интерфейса при движении курсора и периодический опрос сервера. Исправлена привязка управляемых снарядов к конкретной стрелявшей консоли.

## Почему / Баланс
Снижает сетевую и серверную нагрузку при нескольких открытых консолях.

## Технические детали
- Курсор вынесен в отдельное лёгкое BUI-сообщение.
- Полный UI-state обновляется по событиям и ограничен четырьмя отправками в секунду.
- Обновления отправляются только открытым консолям.
- Управляемые снаряды привязываются к консоли и пользователю текущей сессии стрельбы.
- Сканнер масс и консоль шаттла не изменялись.

<!--CLIgnore-->
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- fix: Оптимизирована работа орудийных консолей. Меньше сетевой нагрузки при стрельбе.