### PR TITLE
Magboots fixes

### DIFF
--- a/Content.IntegrationTests/Tests/_Exodus/Gravity/IntrinsicMagbootsTests.cs
+++ b/Content.IntegrationTests/Tests/_Exodus/Gravity/IntrinsicMagbootsTests.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Clothing;
+using Content.Shared.Gravity;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._Exodus.Gravity;
+
+[TestFixture]
+[TestOf(typeof(SharedMagbootsSystem))]
+public sealed class IntrinsicMagbootsTests
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: IntrinsicMagbootsDummy
+  components:
+  - type: Physics
+    bodyType: Dynamic
+  - type: GravityAffected
+  - type: ItemToggle
+  - type: Magboots
+";
+
+    [Test]
+    public async Task TogglingRefreshesWeightlessness()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.EntMan;
+        var toggleSystem = entityManager.System<ItemToggleSystem>();
+        var testMap = await pair.CreateTestMap();
+
+        EntityUid magboots = default;
+
+        await server.WaitAssertion(() =>
+        {
+            magboots = entityManager.SpawnEntity("IntrinsicMagbootsDummy", testMap.GridCoords);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var gravity = entityManager.GetComponent<GravityAffectedComponent>(magboots);
+            var toggle = entityManager.GetComponent<ItemToggleComponent>(magboots);
+
+            Assert.That(gravity.Weightless, Is.True);
+            Assert.That(toggleSystem.TryActivate(magboots, predicted: false), Is.True);
+            Assert.That(toggle.Activated, Is.True);
+            Assert.That(gravity.Weightless, Is.False);
+
+            Assert.That(toggleSystem.TryDeactivate(magboots, predicted: false), Is.True);
+            Assert.That(toggle.Activated, Is.False);
+            Assert.That(gravity.Weightless, Is.True);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -34,6 +34,8 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
 
     private void OnToggled(Entity<MagbootsComponent> ent, ref ItemToggledEvent args)
     {
+        _gravity.RefreshWeightless(ent.Owner); // Exodus intrinsic-magboots-gravity-refresh
+
         if (_container.TryGetContainingContainer((ent.Owner, null, null), out var container))
             UpdateMagbootEffects(container.Owner, ent, args.Activated);
 


### PR DESCRIPTION
## Описание PR
Переключение Magboots теперь обновляет GravityAffected самого владельца. Встроенные магбуты борга сразу снимают ошибочную невесомость.

Баг: Борг который реснулся без гравитации, ошибочно имеет ускорение как в космосе, но при этом находится на гриде -> движение крайне затруднительно.

Добавил тесты на подобные случаи, чтобы не повторялось более.

## Почему / Баланс
Апстрим насрал, исправляем баги за апстримом.


<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- fix: Борги которые появились на гриде без гравитации теперь корректно обладают свойством магбутсов.
