### PR TITLE
Disk Magnet RND Servers

### DIFF
--- a/Content.Server/_Exodus/Research/ResearchServerDiskMagnetComponent.cs
+++ b/Content.Server/_Exodus/Research/ResearchServerDiskMagnetComponent.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Server._Exodus.Research;
+
+/// <summary>
+/// Periodically offers nearby whitelisted entities to an R&amp;D server for insertion.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ResearchServerDiskMagnetComponent : Component
+{
+    /// <summary>
+    /// Maximum pickup range in tiles.
+    /// </summary>
+    [DataField]
+    public float Range = 1.5f;
+
+    /// <summary>
+    /// Delay between pickup scans.
+    /// </summary>
+    [DataField]
+    public TimeSpan ScanInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Maximum number of entities that may be inserted during a single scan.
+    /// </summary>
+    [DataField]
+    public int MaxEntitiesPerScan = 15;
+
+    /// <summary>
+    /// Whether the receiver must have a powered APC connection to scan.
+    /// </summary>
+    [DataField]
+    public bool RequiresPower = true;
+
+    /// <summary>
+    /// Whether candidates must be resting on the ground.
+    /// </summary>
+    [DataField]
+    public bool OnlyOnGround = true;
+
+    /// <summary>
+    /// Entities eligible for an insertion attempt. Null accepts every nearby entity.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// Whether the magnet is currently enabled.
+    /// </summary>
+    [DataField]
+    public bool MagnetEnabled;
+
+    /// <summary>
+    /// Absolute time of the next scan. Runtime state only.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan NextScan;
+}

--- a/Content.Server/_Exodus/Research/ResearchServerDiskMagnetIntegrationSystem.cs
+++ b/Content.Server/_Exodus/Research/ResearchServerDiskMagnetIntegrationSystem.cs
@@ -1,0 +1,66 @@
+using Content.Server.Popups;
+using Content.Server.Research.Disk;
+using Content.Server.Research.Systems;
+using Content.Shared.Research.Components;
+using Content.Shared.Research.Systems;
+using Content.Shared.Research.TechnologyDisk.Components;
+
+namespace Content.Server._Exodus.Research;
+
+/// <summary>
+/// Handles the research point and technology disk integrations for the R&amp;D server magnet.
+/// Additional media types can handle <see cref="ResearchServerMagnetInsertAttemptEvent"/> independently.
+/// </summary>
+public sealed class ResearchServerDiskMagnetIntegrationSystem : EntitySystem
+{
+    [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private ResearchSystem _research = default!;
+    [Dependency] private SharedResearchSystem _sharedResearch = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ResearchDiskComponent, ResearchServerMagnetInsertAttemptEvent>(OnResearchDiskInsertAttempt);
+        SubscribeLocalEvent<TechnologyDiskComponent, ResearchServerMagnetInsertAttemptEvent>(OnTechnologyDiskInsertAttempt);
+    }
+
+    private void OnResearchDiskInsertAttempt(Entity<ResearchDiskComponent> ent,
+        ref ResearchServerMagnetInsertAttemptEvent args)
+    {
+        if (args.Handled || TerminatingOrDeleted(ent) || TerminatingOrDeleted(args.Server))
+            return;
+
+        if (!TryQueueDel(ent))
+            return;
+
+        _research.ModifyServerPoints(args.Server, ent.Comp.Points, args.Server.Comp);
+        _popup.PopupEntity(Loc.GetString("research-server-disk-magnet-inserted-points", ("points", ent.Comp.Points)),
+            args.Server);
+        args.Handled = true;
+    }
+
+    private void OnTechnologyDiskInsertAttempt(Entity<TechnologyDiskComponent> ent,
+        ref ResearchServerMagnetInsertAttemptEvent args)
+    {
+        if (args.Handled || TerminatingOrDeleted(ent) || TerminatingOrDeleted(args.Server) ||
+            !TryComp<TechnologyDatabaseComponent>(args.Server, out var database))
+        {
+            return;
+        }
+
+        if (!TryQueueDel(ent))
+            return;
+
+        if (ent.Comp.Recipes != null)
+        {
+            foreach (var recipe in ent.Comp.Recipes)
+            {
+                _sharedResearch.AddLatheRecipe(args.Server, recipe, database);
+            }
+        }
+
+        _popup.PopupEntity(Loc.GetString("research-server-disk-magnet-inserted-technology"), args.Server);
+        args.Handled = true;
+    }
+}

--- a/Content.Server/_Exodus/Research/ResearchServerDiskMagnetSystem.cs
+++ b/Content.Server/_Exodus/Research/ResearchServerDiskMagnetSystem.cs
@@ -1,0 +1,190 @@
+using Content.Server.Power.Components;
+using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
+using Content.Shared.Research.Components;
+using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Exodus.Research;
+
+/// <summary>
+/// Finds nearby entities allowed by <see cref="ResearchServerDiskMagnetComponent.Whitelist"/>
+/// and lets their systems handle insertion into an R&amp;D server.
+/// </summary>
+public sealed class ResearchServerDiskMagnetSystem : EntitySystem
+{
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    private readonly HashSet<EntityUid> _nearbyEntities = new();
+
+    private EntityQuery<ApcPowerReceiverComponent> _powerQuery;
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    private TimeSpan _nextScan = TimeSpan.MaxValue;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _powerQuery = GetEntityQuery<ApcPowerReceiverComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+
+        SubscribeLocalEvent<ResearchServerDiskMagnetComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<ResearchServerDiskMagnetComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<ResearchServerDiskMagnetComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+    }
+
+    private void OnMagnetMapInit(Entity<ResearchServerDiskMagnetComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextScan = _timing.CurTime;
+
+        if (ent.Comp.MagnetEnabled && ent.Comp.ScanInterval > TimeSpan.Zero)
+            ScheduleScan(ent.Comp.NextScan);
+    }
+
+    private void OnGetVerbs(Entity<ResearchServerDiskMagnetComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || !HasComp<HandsComponent>(args.User))
+            return;
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Act = () => SetEnabled(ent, !ent.Comp.MagnetEnabled),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
+            Priority = 3,
+        });
+    }
+
+    private void OnExamined(Entity<ResearchServerDiskMagnetComponent> ent, ref ExaminedEvent args)
+    {
+        var state = Loc.GetString(ent.Comp.MagnetEnabled
+            ? "magnet-pickup-component-magnet-on"
+            : "magnet-pickup-component-magnet-off");
+
+        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main", ("stateText", state)));
+    }
+
+    public void SetEnabled(Entity<ResearchServerDiskMagnetComponent> ent, bool enabled)
+    {
+        if (TerminatingOrDeleted(ent) || ent.Comp.MagnetEnabled == enabled)
+            return;
+
+        ent.Comp.MagnetEnabled = enabled;
+        if (!enabled || ent.Comp.ScanInterval <= TimeSpan.Zero)
+            return;
+
+        ent.Comp.NextScan = _timing.CurTime;
+        ScheduleScan(ent.Comp.NextScan);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var currentTime = _timing.CurTime;
+        if (currentTime < _nextScan)
+            return;
+
+        var nextScan = TimeSpan.MaxValue;
+        var query = EntityManager.AllEntityQueryEnumerator<ResearchServerDiskMagnetComponent,
+            ResearchServerComponent,
+            TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var magnet, out var server, out var xform))
+        {
+            if (TerminatingOrDeleted(uid) || !magnet.MagnetEnabled || magnet.ScanInterval <= TimeSpan.Zero)
+                continue;
+
+            if (magnet.NextScan > currentTime)
+            {
+                nextScan = Min(nextScan, magnet.NextScan);
+                continue;
+            }
+
+            magnet.NextScan = currentTime + magnet.ScanInterval;
+            nextScan = Min(nextScan, magnet.NextScan);
+
+            if (IsPaused(uid) ||
+                magnet.Range <= 0f ||
+                magnet.MaxEntitiesPerScan <= 0 ||
+                !HasRequiredPower((uid, magnet)))
+            {
+                continue;
+            }
+
+            ScanForEntities((uid, magnet, server, xform));
+        }
+
+        _nextScan = nextScan;
+    }
+
+    private void ScanForEntities(
+        Entity<ResearchServerDiskMagnetComponent, ResearchServerComponent, TransformComponent> ent)
+    {
+        _nearbyEntities.Clear();
+        _lookup.GetEntitiesInRange(ent.Comp3.MapID,
+            _transform.GetWorldPosition(ent.Comp3),
+            ent.Comp1.Range,
+            _nearbyEntities,
+            LookupFlags.Dynamic | LookupFlags.Sundries);
+
+        var inserted = 0;
+        var parent = ent.Comp3.ParentUid;
+
+        foreach (var candidate in _nearbyEntities)
+        {
+            if (inserted >= ent.Comp1.MaxEntitiesPerScan)
+                break;
+
+            if (candidate == ent.Owner || candidate == parent || TerminatingOrDeleted(candidate) ||
+                _whitelist.IsWhitelistFail(ent.Comp1.Whitelist, candidate))
+            {
+                continue;
+            }
+
+            if (ent.Comp1.OnlyOnGround &&
+                (!_physicsQuery.TryComp(candidate, out var physics) || physics.BodyStatus != BodyStatus.OnGround))
+            {
+                continue;
+            }
+
+            var insertAttempt = new ResearchServerMagnetInsertAttemptEvent((ent.Owner, ent.Comp2));
+            RaiseLocalEvent(candidate, ref insertAttempt);
+
+            if (insertAttempt.Handled)
+                inserted++;
+        }
+    }
+
+    private bool HasRequiredPower(Entity<ResearchServerDiskMagnetComponent> ent)
+    {
+        return !ent.Comp.RequiresPower ||
+               _powerQuery.TryComp(ent, out var power) && power.Powered;
+    }
+
+    private void ScheduleScan(TimeSpan scanTime)
+    {
+        _nextScan = Min(_nextScan, scanTime);
+    }
+
+    private static TimeSpan Min(TimeSpan first, TimeSpan second)
+    {
+        return first <= second ? first : second;
+    }
+}
+
+/// <summary>
+/// Raised on a nearby whitelisted entity so its system can insert it into the R&amp;D server.
+/// </summary>
+[ByRefEvent]
+public record struct ResearchServerMagnetInsertAttemptEvent(Entity<ResearchServerComponent> Server)
+{
+    public bool Handled;
+}

--- a/Resources/Locale/en-US/_Exodus/research/research-server-disk-magnet.ftl
+++ b/Resources/Locale/en-US/_Exodus/research/research-server-disk-magnet.ftl
@@ -1,0 +1,2 @@
+research-server-disk-magnet-inserted-points = The server absorbs a disk, adding {$points} research points.
+research-server-disk-magnet-inserted-technology = The server absorbs a technology disk, adding its recipes to the database.

--- a/Resources/Locale/ru-RU/_Exodus/research/research-server-disk-magnet.ftl
+++ b/Resources/Locale/ru-RU/_Exodus/research/research-server-disk-magnet.ftl
@@ -1,0 +1,2 @@
+research-server-disk-magnet-inserted-points = Сервер поглощает диск, добавляя {$points} очков исследований.
+research-server-disk-magnet-inserted-technology = Сервер поглощает технологический диск, добавляя его рецепты в базу данных.

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ResearchAndDevelopmentServer
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseResearchServerDiskMagnet ] # Exodus
   name: R&D server
   description: Contains the collective knowledge of the station's scientists. Destroying it would send them back to the stone age. You don't want that do you?
   components:

--- a/Resources/Prototypes/_Exodus/Entities/Structures/Machines/research_server.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Structures/Machines/research_server.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: BaseResearchServerDiskMagnet
+  abstract: true
+  components:
+  - type: ResearchServerDiskMagnet
+    range: 1.5
+    scanInterval: 1
+    maxEntitiesPerScan: 15
+    requiresPower: true
+    onlyOnGround: true
+    magnetEnabled: false
+    whitelist:
+      components:
+      - ResearchDisk
+      - TechnologyDisk

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/faction_servers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/faction_servers.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseRdServerFaction
-  parent: BaseMachinePowered
+  parent: [BaseMachinePowered, BaseResearchServerDiskMagnet] # Exodus
   name: BaseRdServerFaction
   categories: [ HideSpawnMenu ]
   description: Contains the collective knowledge of the faction.


### PR DESCRIPTION
## Описание PR
Добавил магнит для дисков для сервера РНД.

## Почему / Баланс
QoL.

## Технические детали
Добавлен конфигурируемый компонент магнита с настраиваемыми радиусом, интервалом сканирования, лимитом сущностей и вайтлист.

Сканирование отделено от обработки носителей через событие. Диски очков и технологические диски обрабатываются отдельной интеграционной системой.

Существующие системы магнитов не рефакторились, поскольку их объединение существенно расширило бы область изменений и потребовало отдельной регрессии.

<!--CLIgnore-->
## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!--/CLIgnore-->

**Список изменений**
:cl:
- add: Добавлен магнит для серверов РНД. Он всасывает в себя доступные технологические и исследовательские диски.
