### PR TITLE
IPC Tweak Slowdown DoAfter

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -65,8 +65,8 @@
   - type: StandingState
   - type: DoAfterInterruptionExempt # Exodus do-after-interruption-exemption
     exemptions: [Movement, HandChange]
-    walkSpeedModifier: 0.5 # Exodus do-after-movement-slowdown
-    sprintSpeedModifier: 0.5 # Exodus do-after-movement-slowdown
+    walkSpeedModifier: 0.8 # Exodus do-after-movement-slowdown
+    sprintSpeedModifier: 0.8 # Exodus do-after-movement-slowdown
   - type: MobState
     allowedStates:
     - Alive


### PR DESCRIPTION
## Описание PR
50% замедление при DoAfter слишком сильное для КПБ. Замедляем теперь только на 20%.

## Почему / Баланс
КПБ все равно не сможет догнать игрока, а жизнь на КПБ более приятней.



<!--CLIgnore-->
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [X] Я подтверждаю, что мои изменения находятся под лицензией [Exodus CLA](https://github.com/SerbiaStrong-220/Monolith/blob/master/LICENSES/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->
<!--/CLIgnore-->


**Список изменений**
:cl:
- tweak: Замедление КПБ уменьшено с 50% до 20%, когда они что-либо применяют.
